### PR TITLE
Feature/menu support

### DIFF
--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -130,7 +130,7 @@ if g:mkdx#settings.map.enable == 1
     if (mapcheck(full_mapping, mapmode) == "") && (!plug_mapping || !hasmapto(plug_mapping))
       exe mapmode . 'map <buffer> ' . full_mapping . ' ' . expr
       " if (has('gui'))
-      exe mapmode . 'menu <script> Plugin.mkdx.' . label . (mapmode == 'v' ? '\ (Visual)' : '') . '<TAB> ' . full_mapping . (mapmode == 'i' ? '<C-O>' : '') . ':silent call feedkeys(' . full_mapping . ')'
+      exe mapmode . 'menu <script> Plugin.mkdx.' . label . (mapmode == 'v' ? '\ (Visual)' : '') . '<TAB> ' . full_mapping . (mapmode == 'i' ? '<C-O>' : '') . ':silent call feedkeys("' . full_mapping . '")<cr>'
       " endif
     endif
   endfor

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -83,36 +83,36 @@ if g:mkdx#settings.map.enable == 1
   let s:ftilde   = empty(s:fstyle) ? '~~~' : s:fstyle
   let s:gv       = g:mkdx#settings.restore_visual == 1 ? 'gv' : ''
   let s:bindings = [
-        \ ['Toggle\ checkbox\ backward',    1, 'n',     '-',      '<Plug>(mkdx-checkbox-prev)'],
-        \ ['Toggle\ checkbox\ forward',     1, 'n',     '=',      '<Plug>(mkdx-checkbox-next)'],
-        \ ['Toggle\ checkbox\ forward',     1, 'v',     '-',      '<Plug>(mkdx-checkbox-prev)' . s:gv],
-        \ ['Toggle\ checkbox\ backward',    1, 'v',     '=',      '<Plug>(mkdx-checkbox-next)' . s:gv],
-        \ ['Promote\ header',               1, 'n',     '[',      '<Plug>(mkdx-promote-header)'],
-        \ ['Demote\ header',                1, 'n',     ']',      '<Plug>(mkdx-demote-header)'],
-        \ ['Toggle\ quote',                 1, 'n',     "'",      '<Plug>(mkdx-toggle-quote)'],
-        \ ['Toggle\ quote',                 1, 'v',     "'",      '<Plug>(mkdx-toggle-quote)' . s:gv],
-        \ ['Toggle\ checkbox',              1, 'n',     "t",      '<Plug>(mkdx-toggle-checkbox)'],
-        \ ['Toggle\ checkbox',              1, 'v',     "t",      '<Plug>(mkdx-toggle-checkbox)' . s:gv],
-        \ ['Toggle\ checklist',             1, 'n',     "lt",     '<Plug>(mkdx-toggle-checklist)'],
-        \ ['Toggle\ checklist',             1, 'v',     "lt",     '<Plug>(mkdx-toggle-checklist)' . s:gv],
-        \ ['Toggle\ list',                  1, 'n',     "ll",     '<Plug>(mkdx-toggle-list)'],
-        \ ['Toggle\ list',                  1, 'v',     "ll",     '<Plug>(mkdx-toggle-list)' . s:gv],
-        \ ['Wrap\ link',                    1, 'n',     'ln',     '<Plug>(mkdx-wrap-link-n)'],
-        \ ['Wrap\ link',                    1, 'v',     'ln',     '<Plug>(mkdx-wrap-link-v)'],
-        \ ['Italic',                        1, 'n',     '/',      '<Plug>(mkdx-text-italic-n)'],
-        \ ['Italic',                        1, 'v',     '/',      '<Plug>(mkdx-text-italic-v)'],
-        \ ['Bold',                          1, 'n',     'b',      '<Plug>(mkdx-text-bold-n)'],
-        \ ['Bold',                          1, 'v',     'b',      '<Plug>(mkdx-text-bold-v)'],
-        \ ['Inline\ code',                  1, 'n',     '`',      '<Plug>(mkdx-text-inline-code-n)'],
-        \ ['Inline\ code',                  1, 'v',     '`',      '<Plug>(mkdx-text-inline-code-v)'],
-        \ ['Strike\ through',               1, 'n',     's',      '<Plug>(mkdx-text-strike-n)'],
-        \ ['Strike\ through',               1, 'v',     's',      '<Plug>(mkdx-text-strike-v)'],
-        \ ['Convert to table',              1, 'v',     ',',      '<Plug>(mkdx-tableize)'],
-        \ ['Generate\ /\ Update\ TOC',      1, 'n',     'i',      '<Plug>(mkdx-gen-or-upd-toc)'],
-        \ ['Open\ TOC\ in\ quickfix',       1, 'n',     'I',      '<Plug>(mkdx-quickfix-toc)'],
-        \ ['Insert\ kbd\ tag',              0, 'i',     '<<tab>', '<kbd></kbd>2hcit'],
-        \ ['Backtick\ fenced\ code\ block', 0, 'inore', '```',    s:fbtick . '' . s:fbtick . 'kA'],
-        \ ['tilde\ fenced\ code\ block',    0, 'inore', '~~~',    s:ftilde . '' . s:ftilde . 'kA']
+        \ ['Toggle\ checkbox\ backward',    1, 'n', '-',      '<Plug>(mkdx-checkbox-prev)',           ':call mkdx#ToggleCheckboxState(1)<cr>'],
+        \ ['Toggle\ checkbox\ forward',     1, 'n', '=',      '<Plug>(mkdx-checkbox-next)',           ':call mkdx#ToggleCheckboxState()<cr>'],
+        \ ['Toggle\ checkbox\ forward',     1, 'v', '-',      '<Plug>(mkdx-checkbox-prev)' . s:gv,    ':call mkdx#ToggleCheckboxState()<cr>' . s:gv],
+        \ ['Toggle\ checkbox\ backward',    1, 'v', '=',      '<Plug>(mkdx-checkbox-next)' . s:gv,    ':call mkdx#ToggleCheckboxState(1)<cr>' . s:gv],
+        \ ['Promote\ header',               1, 'n', '[',      '<Plug>(mkdx-promote-header)',          ':<C-U>call mkdx#ToggleHeader(1)<cr>'],
+        \ ['Demote\ header',                1, 'n', ']',      '<Plug>(mkdx-demote-header)',           ':<C-U>call mkdx#ToggleHeader()<cr>'],
+        \ ['Toggle\ quote',                 1, 'n', "'",      '<Plug>(mkdx-toggle-quote)',            ':call mkdx#ToggleQuote()<cr>'],
+        \ ['Toggle\ quote',                 1, 'v', "'",      '<Plug>(mkdx-toggle-quote)' . s:gv,     ':call mkdx#ToggleQuote()<cr>' . s:gv],
+        \ ['Toggle\ checkbox',              1, 'n', "t",      '<Plug>(mkdx-toggle-checkbox)',         ':call mkdx#ToggleCheckboxTask()<cr>'],
+        \ ['Toggle\ checkbox',              1, 'v', "t",      '<Plug>(mkdx-toggle-checkbox)' . s:gv,  ':call mkdx#ToggleCheckboxTask()<cr>' . s:gv],
+        \ ['Toggle\ checklist',             1, 'n', "lt",     '<Plug>(mkdx-toggle-checklist)',        ':call mkdx#ToggleChecklist()<cr>'],
+        \ ['Toggle\ checklist',             1, 'v', "lt",     '<Plug>(mkdx-toggle-checklist)' . s:gv, ':call mkdx#ToggleChecklist()<cr>' . s:gv],
+        \ ['Toggle\ list',                  1, 'n', "ll",     '<Plug>(mkdx-toggle-list)',             ':call mkdx#ToggleList()<cr>'],
+        \ ['Toggle\ list',                  1, 'v', "ll",     '<Plug>(mkdx-toggle-list)' . s:gv,      ':call mkdx#ToggleList()<cr>' . s:gv],
+        \ ['Wrap\ link',                    1, 'n', 'ln',     '<Plug>(mkdx-wrap-link-n)',             ':<C-U>call mkdx#WrapLink()<cr>'],
+        \ ['Wrap\ link',                    1, 'v', 'ln',     '<Plug>(mkdx-wrap-link-v)',             ':<C-U>call mkdx#WrapLink("v")<cr>'],
+        \ ['Italic',                        1, 'n', '/',      '<Plug>(mkdx-text-italic-n)',           ':<C-U>call mkdx#WrapText("n", g:mkdx#settings.tokens.italic, g:mkdx#settings.tokens.italic, "mkdx-text-italic-n")<Cr>'],
+        \ ['Italic',                        1, 'v', '/',      '<Plug>(mkdx-text-italic-v)',           ':<C-U>call mkdx#WrapText("v", g:mkdx#settings.tokens.italic, g:mkdx#settings.tokens.italic)<Cr>'],
+        \ ['Bold',                          1, 'n', 'b',      '<Plug>(mkdx-text-bold-n)',             ':<C-U>call mkdx#WrapText("n", g:mkdx#settings.tokens.bold, g:mkdx#settings.tokens.bold, "mkdx-text-bold-n")<Cr>'],
+        \ ['Bold',                          1, 'v', 'b',      '<Plug>(mkdx-text-bold-v)',             ':<C-U>call mkdx#WrapText("v", g:mkdx#settings.tokens.bold, g:mkdx#settings.tokens.bold)<Cr>'],
+        \ ['Inline\ code',                  1, 'n', '`',      '<Plug>(mkdx-text-inline-code-n)',      ':<C-U>call mkdx#WrapText("n", "`", "`", "mkdx-text-inline-code-n")<cr>'],
+        \ ['Inline\ code',                  1, 'v', '`',      '<Plug>(mkdx-text-inline-code-v)',      ':<C-U>call mkdx#WrapText("v", "`", "`")<cr>'],
+        \ ['Strike\ through',               1, 'n', 's',      '<Plug>(mkdx-text-strike-n)',           ':<C-U>call mkdx#WrapText("n", "<strike>", "</strike>", "mkdx-text-strike-n")<cr>'],
+        \ ['Strike\ through',               1, 'v', 's',      '<Plug>(mkdx-text-strike-v)',           ':<C-U>call mkdx#WrapText("v", "<strike>", "</strike>")<cr>'],
+        \ ['Convert\ to\ table',            1, 'v', ',',      '<Plug>(mkdx-tableize)',                ':call mkdx#Tableize()<cr>'],
+        \ ['Generate\ /\ Update\ TOC',      1, 'n', 'i',      '<Plug>(mkdx-gen-or-upd-toc)',          ':call mkdx#GenerateOrUpdateTOC()<cr>'],
+        \ ['Open\ TOC\ in\ quickfix',       1, 'n', 'I',      '<Plug>(mkdx-quickfix-toc)',            ':call mkdx#QuickfixHeaders()<cr>'],
+        \ ['Insert\ kbd\ tag',              0, 'i', '<<tab>', '<kbd></kbd>2hcit',                 ''],
+        \ ['Backtick\ fenced\ code\ block', 0, 'i', '```',    s:fbtick . '' . s:fbtick . 'kA',  ''],
+        \ ['tilde\ fenced\ code\ block',    0, 'i', '~~~',    s:ftilde . '' . s:ftilde . 'kA',  '']
         \ ]
 
   if (g:mkdx#settings.enter.enable)
@@ -123,15 +123,15 @@ if g:mkdx#settings.map.enable == 1
     endif
   endif
 
-  for [label, prefix, mapmode, binding, expr] in s:bindings
+  for [label, prefix, mapmode, binding, expr, cmd] in s:bindings
     let full_mapping = (prefix ? g:mkdx#settings.map.prefix : '') . binding
     let plug_mapping = get(matchlist(binding, '<Plug>([^)]\+)'), 0, -1)
 
     if (mapcheck(full_mapping, mapmode) == "") && (!plug_mapping || !hasmapto(plug_mapping))
       exe mapmode . 'map <buffer> ' . full_mapping . ' ' . expr
-      " if (has('gui'))
-      exe mapmode . 'menu <script> Plugin.mkdx.' . label . (mapmode == 'v' ? '\ (Visual)' : '') . '<TAB> ' . full_mapping . (mapmode == 'i' ? '<C-O>' : '') . ':silent call feedkeys("' . full_mapping . '")<cr>'
-      " endif
+      if (!empty(cmd) && has('menu'))
+          exe mapmode[0] . 'noremenu <script> Plugin.mkdx.' . label . (mapmode == 'v' ? '\ (Visual)' : '') . '<tab>' . full_mapping . ' ' . cmd
+      end
     endif
   endfor
 endif

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -83,36 +83,36 @@ if g:mkdx#settings.map.enable == 1
   let s:ftilde   = empty(s:fstyle) ? '~~~' : s:fstyle
   let s:gv       = g:mkdx#settings.restore_visual == 1 ? 'gv' : ''
   let s:bindings = [
-        \ [1, 'n',     '-',      '<Plug>(mkdx-checkbox-prev)'],
-        \ [1, 'n',     '=',      '<Plug>(mkdx-checkbox-next)'],
-        \ [1, 'v',     '-',      '<Plug>(mkdx-checkbox-prev)' . s:gv],
-        \ [1, 'v',     '=',      '<Plug>(mkdx-checkbox-next)' . s:gv],
-        \ [1, 'n',     '[',      '<Plug>(mkdx-promote-header)'],
-        \ [1, 'n',     ']',      '<Plug>(mkdx-demote-header)'],
-        \ [1, 'n',     "'",      '<Plug>(mkdx-toggle-quote)'],
-        \ [1, 'v',     "'",      '<Plug>(mkdx-toggle-quote)' . s:gv],
-        \ [1, 'n',     "t",      '<Plug>(mkdx-toggle-checkbox)'],
-        \ [1, 'v',     "t",      '<Plug>(mkdx-toggle-checkbox)' . s:gv],
-        \ [1, 'n',     "lt",     '<Plug>(mkdx-toggle-checklist)'],
-        \ [1, 'v',     "lt",     '<Plug>(mkdx-toggle-checklist)' . s:gv],
-        \ [1, 'n',     "ll",     '<Plug>(mkdx-toggle-list)'],
-        \ [1, 'v',     "ll",     '<Plug>(mkdx-toggle-list)' . s:gv],
-        \ [1, 'n',     'ln',     '<Plug>(mkdx-wrap-link-n)'],
-        \ [1, 'v',     'ln',     '<Plug>(mkdx-wrap-link-v)'],
-        \ [1, 'n',     '/',      '<Plug>(mkdx-text-italic-n)'],
-        \ [1, 'n',     'b',      '<Plug>(mkdx-text-bold-n)'],
-        \ [1, 'n',     '`',      '<Plug>(mkdx-text-inline-code-n)'],
-        \ [1, 'n',     's',      '<Plug>(mkdx-text-strike-n)'],
-        \ [1, 'v',     '/',      '<Plug>(mkdx-text-italic-v)'],
-        \ [1, 'v',     'b',      '<Plug>(mkdx-text-bold-v)'],
-        \ [1, 'v',     '`',      '<Plug>(mkdx-text-inline-code-v)'],
-        \ [1, 'v',     's',      '<Plug>(mkdx-text-strike-v)'],
-        \ [1, 'v',     ',',      '<Plug>(mkdx-tableize)'],
-        \ [1, 'n',     'i',      '<Plug>(mkdx-gen-or-upd-toc)'],
-        \ [1, 'n',     'I',      '<Plug>(mkdx-quickfix-toc)'],
-        \ [0, 'i',     '<<tab>', '<kbd></kbd>2hcit'],
-        \ [0, 'inore', '```',    s:fbtick . '' . s:fbtick . 'kA'],
-        \ [0, 'inore', '~~~',    s:ftilde . '' . s:ftilde . 'kA']
+        \ ['Toggle\ checkbox\ backward',    1, 'n',     '-',      '<Plug>(mkdx-checkbox-prev)'],
+        \ ['Toggle\ checkbox\ forward',     1, 'n',     '=',      '<Plug>(mkdx-checkbox-next)'],
+        \ ['Toggle\ checkbox\ forward',     1, 'v',     '-',      '<Plug>(mkdx-checkbox-prev)' . s:gv],
+        \ ['Toggle\ checkbox\ backward',    1, 'v',     '=',      '<Plug>(mkdx-checkbox-next)' . s:gv],
+        \ ['Promote\ header',               1, 'n',     '[',      '<Plug>(mkdx-promote-header)'],
+        \ ['Demote\ header',                1, 'n',     ']',      '<Plug>(mkdx-demote-header)'],
+        \ ['Toggle\ quote',                 1, 'n',     "'",      '<Plug>(mkdx-toggle-quote)'],
+        \ ['Toggle\ quote',                 1, 'v',     "'",      '<Plug>(mkdx-toggle-quote)' . s:gv],
+        \ ['Toggle\ checkbox',              1, 'n',     "t",      '<Plug>(mkdx-toggle-checkbox)'],
+        \ ['Toggle\ checkbox',              1, 'v',     "t",      '<Plug>(mkdx-toggle-checkbox)' . s:gv],
+        \ ['Toggle\ checklist',             1, 'n',     "lt",     '<Plug>(mkdx-toggle-checklist)'],
+        \ ['Toggle\ checklist',             1, 'v',     "lt",     '<Plug>(mkdx-toggle-checklist)' . s:gv],
+        \ ['Toggle\ list',                  1, 'n',     "ll",     '<Plug>(mkdx-toggle-list)'],
+        \ ['Toggle\ list',                  1, 'v',     "ll",     '<Plug>(mkdx-toggle-list)' . s:gv],
+        \ ['Wrap\ link',                    1, 'n',     'ln',     '<Plug>(mkdx-wrap-link-n)'],
+        \ ['Wrap\ link',                    1, 'v',     'ln',     '<Plug>(mkdx-wrap-link-v)'],
+        \ ['Italic',                        1, 'n',     '/',      '<Plug>(mkdx-text-italic-n)'],
+        \ ['Italic',                        1, 'v',     '/',      '<Plug>(mkdx-text-italic-v)'],
+        \ ['Bold',                          1, 'n',     'b',      '<Plug>(mkdx-text-bold-n)'],
+        \ ['Bold',                          1, 'v',     'b',      '<Plug>(mkdx-text-bold-v)'],
+        \ ['Inline\ code',                  1, 'n',     '`',      '<Plug>(mkdx-text-inline-code-n)'],
+        \ ['Inline\ code',                  1, 'v',     '`',      '<Plug>(mkdx-text-inline-code-v)'],
+        \ ['Strike\ through',               1, 'n',     's',      '<Plug>(mkdx-text-strike-n)'],
+        \ ['Strike\ through',               1, 'v',     's',      '<Plug>(mkdx-text-strike-v)'],
+        \ ['Convert to table',              1, 'v',     ',',      '<Plug>(mkdx-tableize)'],
+        \ ['Generate\ /\ Update\ TOC',      1, 'n',     'i',      '<Plug>(mkdx-gen-or-upd-toc)'],
+        \ ['Open\ TOC\ in\ quickfix',       1, 'n',     'I',      '<Plug>(mkdx-quickfix-toc)'],
+        \ ['Insert\ kbd\ tag',              0, 'i',     '<<tab>', '<kbd></kbd>2hcit'],
+        \ ['Backtick\ fenced\ code\ block', 0, 'inore', '```',    s:fbtick . '' . s:fbtick . 'kA'],
+        \ ['tilde\ fenced\ code\ block',    0, 'inore', '~~~',    s:ftilde . '' . s:ftilde . 'kA']
         \ ]
 
   if (g:mkdx#settings.enter.enable)
@@ -123,12 +123,15 @@ if g:mkdx#settings.map.enable == 1
     endif
   endif
 
-  for [prefix, mapmode, binding, expr] in s:bindings
+  for [label, prefix, mapmode, binding, expr] in s:bindings
     let full_mapping = (prefix ? g:mkdx#settings.map.prefix : '') . binding
     let plug_mapping = get(matchlist(binding, '<Plug>([^)]\+)'), 0, -1)
 
     if (mapcheck(full_mapping, mapmode) == "") && (!plug_mapping || !hasmapto(plug_mapping))
       exe mapmode . 'map <buffer> ' . full_mapping . ' ' . expr
+      " if (has('gui'))
+      exe mapmode . 'menu <script> Plugin.mkdx.' . label . (mapmode == 'v' ? '\ (Visual)' : '') . '<TAB> ' . full_mapping . (mapmode == 'i' ? '<C-O>' : '') . ':silent call feedkeys(' . full_mapping . ')'
+      " endif
     endif
   endfor
 endif

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -123,15 +123,16 @@ if g:mkdx#settings.map.enable == 1
     endif
   endif
 
-  for [label, prefix, mapmode, binding, expr, cmd] in s:bindings
+  for [label, prefix, mapmode, binding, plug, cmd] in s:bindings
     let full_mapping = (prefix ? g:mkdx#settings.map.prefix : '') . binding
     let plug_mapping = get(matchlist(binding, '<Plug>([^)]\+)'), 0, -1)
 
     if (mapcheck(full_mapping, mapmode) == "") && (!plug_mapping || !hasmapto(plug_mapping))
-      exe mapmode . 'map <buffer> ' . full_mapping . ' ' . expr
       if (!empty(cmd) && has('menu'))
           exe mapmode[0] . 'noremenu <script> Plugin.mkdx.' . label . (mapmode == 'v' ? '\ (Visual)' : '') . '<tab>' . full_mapping . ' ' . cmd
       end
+
+      exe mapmode . 'map <buffer> ' . full_mapping . ' ' . plug
     endif
   endfor
 endif

--- a/test/setup.vader
+++ b/test/setup.vader
@@ -1,4 +1,5 @@
 Execute (Setup):
   setf markdown
   set sw=4
+  set autoindent
 


### PR DESCRIPTION
Adds menu support from #1 for gvim/macvim users.
Tested in latest MacVim (including executing every action in normal and visual mode)
Menu keys in MacVim become visible after hovering over the menu item for a little while:

![image](https://user-images.githubusercontent.com/3225058/34907358-a9af4e3a-f87d-11e7-8cee-08d0d41a9c64.png)

Menu's also work in terminal vim, if it `has('menu')`: `:menu Plugin.mkdx`.

![image](https://user-images.githubusercontent.com/3225058/34907389-242436bc-f87e-11e7-88b0-da101434bd7d.png)

This solves the issue of having to memorize 20+ mappings that this plugin provides by allowing the use of tear-off menu's for graphical vim users.