### PR TITLE
Feature/shift o

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## Version 0.6.0
+
+- This version adds _opt-in_ support for checkbox state highlighting. See [`g:mkdx#settings.highlight.enable`](#gmkdxsettingshighlightenable) for more information.
+
+## Version 0.5.0
+
+- This version introduces a mapping that opens a quickfix window with all your headers loaded.
+  See [Open TOC in quickfix window](open-toc-in-quickfix-window) section for an example.
+
+## Version 0.4.3.1
+
+- Fixes a critical issue with the enter handler functionality where often, it would crash due to missing out of bounds
+array check.
+

--- a/README.md
+++ b/README.md
@@ -83,7 +83,12 @@ settings and examples with default mappings.
 # Changelog
 
 The latest changes will be visible in this list.
-See [CHANGELOG.md](CHANGELOG.md) for older changes. (**note:** currently empty)
+See [CHANGELOG.md](CHANGELOG.md) for older changes.
+
+## Version 0.7.1
+
+Add support for <kbd>shift</kbd>+<kbd>O</kbd> in addition to <kbd>enter</kbd> and <kbd>O</kbd> in normal mode.
+This will put your cursor on a new empty list item above the current line.
 
 ## Version 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ settings and examples with default mappings.
     - [`g:mkdx#settings.table.divider`](#gmkdxsettingstabledivider)
     - [`g:mkdx#settings.enter.enable`](#gmkdxsettingsenterenable)
     - [`g:mkdx#settings.enter.o`](#gmkdxsettingsentero)
+    - [`g:mkdx#settings.enter.shifto`](#gmkdxsettingsentershifto)
     - [`g:mkdx#settings.enter.malformed`](#gmkdxsettingsentermalformed)
     - [`g:mkdx#settings.toc.text`](#gmkdxsettingstoctext)
     - [`g:mkdx#settings.toc.list_token`](#gmkdxsettingstoclist_token)
@@ -384,6 +385,17 @@ Note that [`g:mkdx#settings.enter.enable`](#gmkdxsettingsenterenable) must be `1
 let g:mkdx#settings = { 'enter': { 'o': 1 } }
 ```
 
+## `g:mkdx#settings.enter.shifto`
+
+This setting enables `O` in normal mode to prepend list items above the current line, your cursor will be placed after the newly added item.
+Like [`g:mkdx#settings.enter.o`](#gmkdxsettingsentero), checkboxes are also added if they are present on the cursor line.
+Note that [`g:mkdx#settings.enter.enable`](#gmkdxsettingsenterenable) must be `1` for this to work.
+
+```viml
+" :h mkdx-setting-enter-shifto
+let g:mkdx#settings = { 'enter': { 'shifto': 1 } }
+```
+
 ## `g:mkdx#settings.enter.malformed`
 
 This setting defines behaviour to use when working with improperly indented
@@ -480,6 +492,7 @@ To prevent mapping of a key from happening, see: [unmapping functionality](#unma
 |Insert kbd shortcut|insert|<kbd>\<</kbd>+<kbd>tab</kbd>|`<kbd></kbd><ESC>2hcit`|
 |<kbd>enter</kbd> handler|insert|<kbd>enter</kbd>|`<C-R>=mkdx#EnterHandler()<Cr>`|
 |<kbd>o</kbd> handler|normal|<kbd>o</kbd>|`A<CR>`|
+|<kbd>O</kbd> handler|normal|<kbd>O</kbd>|`:call mkdx#ShiftOHandler()<Cr>`|
 
 # Unmapping functionality
 
@@ -577,7 +590,7 @@ imap <buffer><silent><unique> <<Tab> <kbd></kbd><C-o>2h<C-o>cit
 |![mkdx unordered list](doc/gifs/vim-mkdx-unordered-list.gif)|![mkdx numbered list](doc/gifs/vim-mkdx-numbered-list.gif)|
 
 When [`g:mkdx#settings.enter.enable`](#gmkdxsettingsenterenable) is set (default on), new list tokens will be inserted when
-editing a markdown list. This happens on any <kbd>enter</kbd> in _insert_ mode or <kbd>o</kbd> in normal mode.
+editing a markdown list. This happens on any <kbd>enter</kbd> in _insert_ mode or <kbd>o</kbd> and <kbd>O</kbd> in normal mode by default.
 Additionally, if the list item contains a checkbox (`[ ]` - any state possible) that will also be appended to
 the newly inserted item.
 

--- a/README.md
+++ b/README.md
@@ -105,20 +105,6 @@ word
 [word](|)
 ~~~
 
-## Version 0.6.0
-
-- This version adds _opt-in_ support for checkbox state highlighting. See [`g:mkdx#settings.highlight.enable`](#gmkdxsettingshighlightenable) for more information.
-
-## Version 0.5.0
-
-- This version introduces a mapping that opens a quickfix window with all your headers loaded.
-  See [Open TOC in quickfix window](open-toc-in-quickfix-window) section for an example.
-
-## Version 0.4.3.1
-
-- Fixes a critical issue with the enter handler functionality where often, it would crash due to missing out of bounds
-array check.
-
 # Install
 
 This plugin should work in _vim_ as well as _nvim_, no clue about _gvim_ but since this plugin only manipulates

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -2,7 +2,7 @@
 *mkdx*
 
 `Author:  Sidney Liebrand <sidneyliebrand@gmail.com>`
-`Version: 0.7.0`
+`Version: 0.7.1`
 
 ==============================================================================
 CONTENTS                                                         *mkdx-contents*

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -28,6 +28,7 @@ CONTENTS                                                         *mkdx-contents*
         `g:mkdx#settings.table.divider`
         `g:mkdx#settings.enter.enable`
         `g:mkdx#settings.enter.o`
+        `g:mkdx#settings.enter.shifto`
         `g:mkdx#settings.enter.malformed`
         `g:mkdx#settings.toc.text`
         `g:mkdx#settings.toc.list_token`
@@ -150,6 +151,7 @@ for functions. Below is a list of all helptags:
     - |mkdx-setting-table-divider|
     - |mkdx-setting-enter-enable|
     - |mkdx-setting-enter-o|
+    - |mkdx-setting-enter-shifto|
     - |mkdx-setting-enter-malformed|
     - |mkdx-setting-toc-text|
     - |mkdx-setting-toc-list-token|
@@ -280,6 +282,7 @@ let s:defaults.table.header_divider    `=>` g:mkdx#table_header_divider
 let s:defaults.table.divider           `=>` g:mkdx#table_divider
 let s:defaults.enter.enable            `=>` g:mkdx#enhance_enter
 let s:defaults.enter.o                 `=>`
+let s:defaults.enter.shifto            `=>`
 let s:defaults.tokens.enter            `=>` g:mkdx#list_tokens
 let s:defaults.tokens.fence            `=>` g:mkdx#fence_style
 let s:defaults.enter.malformed         `=>` g:mkdx#handle_malformed_indent
@@ -425,6 +428,12 @@ Examples can be found at |mkdx-function-enter-handler|.
 
 This setting also enables `o` to act like `<enter>` in the middle of lists /
 checklists / tasks.
+
+==============================================================================
+`g:mkdx#settings.enter.shifto`                         *mkdx-setting-enter-shifto*
+
+This setting also enables `O` to prepend a list item above the current line
+and place your cursor on it.
 
 ==============================================================================
 `g:mkdx#settings.enter.malformed = 1`               *mkdx-setting-enter-malformed*

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -2,7 +2,7 @@ if exists('b:did_ftplugin') | finish | else | let b:did_ftplugin = 1 | endif
 let s:defaults = {
       \ 'image_extension_pattern': 'a\?png\|jpe\?g\|gif',
       \ 'restore_visual':          1,
-      \ 'enter':                   { 'enable': 1, 'malformed': 1, 'o': 1 },
+      \ 'enter':                   { 'enable': 1, 'malformed': 1, 'o': 1, 'shifto': 1 },
       \ 'map':                     { 'prefix': '<leader>', 'enable': 1 },
       \ 'tokens':                  { 'enter': ['-', '*', '>'], 'bold': '**', 'italic': '*', 'list': '-', 'fence': '', 'header': '#' },
       \ 'checkbox':                { 'toggles': [' ', '-', 'x'], 'update_tree': 2, 'initial_state': ' ' },
@@ -116,11 +116,16 @@ if g:mkdx#settings.map.enable == 1
         \ ]
 
   if (g:mkdx#settings.enter.enable)
-    imap <buffer><silent> <Cr> <C-R>=mkdx#EnterHandler()<Cr>
+    inoremap <buffer><silent> <S-CR> :echo hello<Cr>
+    inoremap <buffer><silent> <Cr> <C-R>=mkdx#EnterHandler()<Cr>
 
     if (g:mkdx#settings.enter.o)
       nmap <buffer><silent> o A<Cr>
     endif
+
+    if (g:mkdx#settings.enter.shifto)
+      nmap <buffer><silent> O :call mkdx#ShiftOHandler()<Cr>
+    end
   endif
 
   for [label, prefix, mapmode, binding, plug, cmd] in s:bindings

--- a/test/lists.vader
+++ b/test/lists.vader
@@ -34,6 +34,20 @@ Given (A markdown list):
   - list item
   - list item
 
+Do (<O> on a list item prepends a new empty list item):
+  O
+
+Expect (An empty list item):
+  - 
+  - list item
+  - list item
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Given (A markdown list):
+  - list item
+  - list item
+
 Do (<enter> in the middle of list item performs regular <enter>):
   6la\<cr>
 
@@ -47,8 +61,8 @@ Expect (An empty list item):
 Given (A nested numbered list):
   1. task
   2. task
-    2.1. subtask
-    2.2. subtask
+      2.1. subtask
+      2.2. subtask
   3. hello
 
 Do (Press <o> on the item increments other list items):
@@ -58,8 +72,8 @@ Expect (List items are correctly incremented and new empty list item):
   1. task
   2. 
   3. task
-    3.1. subtask
-    3.2. subtask
+      3.1. subtask
+      3.2. subtask
   4. hello
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -67,8 +81,28 @@ Expect (List items are correctly incremented and new empty list item):
 Given (A nested numbered list):
   1. task
   2. task
-    2.1. subtask
-    2.2. subtask
+      2.1. subtask
+      2.2. subtask
+  3. hello
+
+Do (Press <O> on the item increments other list items):
+  O
+
+Expect (List items are correctly incremented and new empty list item):
+  1. 
+  2. task
+  3. task
+      3.1. subtask
+      3.2. subtask
+  4. hello
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Given (A nested numbered list):
+  1. task
+  2. task
+      2.1. subtask
+      2.2. subtask
   3. hello
 
 Do (Press <o> on the first nested item increments other list items):
@@ -77,7 +111,27 @@ Do (Press <o> on the first nested item increments other list items):
 Expect (List items are correctly incremented and new empty list item):
   1. task
   2. task
-    2.1. subtask
-    2.2. 
-    2.3. subtask
+      2.1. subtask
+      2.2. 
+      2.3. subtask
+  3. hello
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Given (A nested numbered list):
+  1. task
+  2. task
+      2.1. subtask
+      2.2. subtask
+  3. hello
+
+Do (Press <O> on the first nested item increments other list items):
+  2jO
+
+Expect (List items are correctly incremented and new empty list item):
+  1. task
+  2. task
+      2.1. 
+      2.2. subtask
+      2.3. subtask
   3. hello


### PR DESCRIPTION
Adds support for shift-o to insert a list item above the current line.
Vader.vim tests are included for shift-o as well.

This fixes the issue of not being able to create a nested list item before the first one, since it now also works upwards, a list item can be inserted anywhere at any level of depth.