### PR TITLE
Fix/space after list items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1172,7 +1172,7 @@ Found a bug or want to report an issue? Take a look at the [CONTRIBUTING](CONTRI
 - [x] ([#17](../../issues/17)) Add a mapping to go to fragment link location.
 - [x] ([#18](../../issues/18)) Add alignment options for columns in a table generated from CSV.
 - [x] ([#18](../../issues/18)) Add alignment options for specific column names or indexes in a table generated from CSV.
-- [ ] Make numeric list items require a space between them and other content to prevent false positives.
+- [x] Make numeric list items require a space between them and other content to prevent false positives.
 
 # Changelog
 

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -312,7 +312,7 @@ endfun
 fun! s:util.ToggleLineType(line, type)
   if (empty(a:line)) | return a:line | endif
 
-  let li_re = '\([0-9.]\+\|[' . join(g:mkdx#settings.tokens.enter, '') . ']\)'
+  let li_re = '\([0-9.]\+\|[' . join(g:mkdx#settings.tokens.enter, '') . ']\) '
 
   if (a:type == 'list')
     " if a:line is a list item, remove the list marker and return
@@ -324,8 +324,8 @@ fun! s:util.ToggleLineType(line, type)
     return substitute(a:line, '^\( *\)', '\1' . g:mkdx#settings.tokens.list . ' ', '')
   elseif (a:type == 'checklist')
     " if a:line is a checklist item, remove the checklist marker and return
-    if (match(a:line, '^ *' . li_re . ' \[.\]') > -1)
-      return substitute(a:line, '^\( *\)' . li_re . ' \[.\] *', '\1', '')
+    if (match(a:line, '^ *' . li_re . ' *\[.\]') > -1)
+      return substitute(a:line, '^\( *\)' . li_re . ' *\[.\] *', '\1', '')
     endif
 
     " if a:line is a checkbox, replace it with g:mkdx#settings.tokens.list followed
@@ -861,7 +861,7 @@ fun! mkdx#ShiftOHandler()
   endif
 
   let lin = bld ? -1 : get(matchlist(line, '^ *\([0-9.]\+\)'), 1, -1)
-  let lis = bld ? -1 : get(matchlist(line, '^ *\([' . join(g:mkdx#settings.tokens.enter, '') . ']\)'), 1, -1)
+  let lis = bld ? -1 : get(matchlist(line, '^ *\([' . join(g:mkdx#settings.tokens.enter, '') . ']\) '), 1, -1)
 
   if (lin != -1)
     let esc  = lin == '*' ? '\*' : lin
@@ -890,20 +890,20 @@ fun! mkdx#EnterHandler()
   if (!empty(line) && g:mkdx#settings.enter.enable)
     let len     = strlen(line)
     let at_end  = cnum > len
-    let sp_pat  = '^>\? *\(\([0-9.]\+\|[' . join(g:mkdx#settings.tokens.enter, '') . ']\)\( \[.\]\)\?\|\[.\]\)'
+    let sp_pat  = '^>\? *\(\([0-9.]\+\|[' . join(g:mkdx#settings.tokens.enter, '') . ']\)\( \[.\]\)\? \|\[.\]\)'
     let results = matchlist(line, sp_pat)
     let t       = get(results, 2, '')
     let tcb     = match(get(results, 1, ''), '^>\? *\[.\] *') > -1
     let cb      = match(get(results, 3, ''), ' *\[.\] *') > -1
     let quote   = len > 0 ? line[0] == '>' : 0
     let remove  = empty(substitute(line, sp_pat . ' *', '', ''))
-    let incr    = len(split(get(matchlist(line, '^>\? *\([0-9.]\+\)'), 1, ''), '\.')) - 1
+    let incr    = len(split(get(matchlist(line, '^>\? *\([0-9.]\+\) '), 1, ''), '\.')) - 1
     let upd_tl  = (cb || tcb) && g:mkdx#settings.checkbox.update_tree != 0 && at_end
     let tl_prms = remove ? [line('.') - 1, -1] : ['.', 1]
     let qu_str  = quote ? ('>' . get(matchlist(line, '^>\?\( *\)'), 1, '')) : ''
     let ast_bld = match(line, '^ *\*\*') > -1
 
-    if (at_end && match(line, '^>\? *[0-9.]\+') > -1)
+    if (at_end && match(line, '^>\? *[0-9.]\+ ') > -1)
       call s:util.UpdateListNumbers(lnum, incr, (remove ? -1 : 1))
     endif
 


### PR DESCRIPTION
This requires list items to require a space after them before autocompleting them.
Before, this was valid:

```markdown
1.hello<enter>
2. <cursor>

1. hello<enter>
2. <cursor>
```

Now it will be ignored by default:

```markdown
1.hello<enter>
<cursor>
```

And only this will be valid:

```markdown
1. hello<enter>
2. <cursor>
```