### PR TITLE
Feature/async completions

### DIFF
--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -2,13 +2,13 @@
 let s:_is_nvim               = has('nvim')
 let s:_has_curl              = executable('curl')
 let s:_has_rg                = 1 && executable('rg')
-let s:_has_ag                = 1 && executable('ag')
-let s:_has_cgrep             = 1 && executable('cgrep')
-let s:_has_ack               = 1 && executable('ack')
-let s:_has_pt                = 1 && executable('pt')
-let s:_has_ucg               = 1 && executable('ucg')
-let s:_has_sift              = 1 && executable('sift')
-let s:_can_async             = s:_is_nvim || has('job')
+let s:_has_ag                = s:_has_rg    || executable('ag')
+let s:_has_cgrep             = s:_has_ag    || executable('cgrep')
+let s:_has_ack               = s:_has_cgrep || executable('ack')
+let s:_has_pt                = s:_has_ack   || executable('pt')
+let s:_has_ucg               = s:_has_pt    || executable('ucg')
+let s:_has_sift              = s:_has_ucg   || executable('sift')
+let s:_can_async             = s:_is_nvim   || has('job')
 let s:util                   = {}
 let s:util.modifier_mappings = {
       \ 'C': 'ctrl',

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -4,9 +4,10 @@ let s:_has_curl              = executable('curl')
 let s:_has_rg                = 0 && executable('rg')
 let s:_has_ag                = 0 && executable('ag')
 let s:_has_ack               = 0 && executable('ack')
-let s:_has_sift              = 1 && executable('sift')
+let s:_has_sift              = 0 && executable('sift')
 let s:_has_cgrep             = 0 && executable('cgrep')
 let s:_has_pt                = 0 && executable('pt')
+let s:_has_ucg               = 1 && executable('ucg')
 let s:_can_async             = s:_is_nvim || has('job')
 let s:util                   = {}
 let s:util.modifier_mappings = {
@@ -22,6 +23,7 @@ let s:util.grepopts = {
       \ 'rg':    { 'timeout': 50,  'opts': ['--vimgrep'] },
       \ 'ag':    { 'timeout': 50,  'opts': ['--vimgrep'] },
       \ 'ack':   { 'timeout': 100, 'opts': ['-H', '--column', '--nogroup'] },
+      \ 'ucg':   { 'timeout': 50,  'opts': ['--column'] },
       \ 'sift':  { 'timeout': 100, 'opts': ['-n', '--column', '--only-matching'] },
       \ 'grep':  { 'timeout': 100, 'opts': ['-o', '--line-number', '--byte-offset'], 'pat_flag': ['-E'] },
       \ 'cgrep': { 'timeout': 50,  'opts': ['--regex-pcre', '--format="#f:#n:#0"'] },
@@ -40,6 +42,8 @@ elseif (s:_has_ack)
   let s:util.grepcmd = 'ack'
 elseif (s:_has_pt)
   let s:util.grepcmd = 'pt'
+elseif (s:_has_ucg)
+  let s:util.grepcmd = 'ucg'
 else
   let s:util.grepcmd = 'grep'
 endif

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -5,6 +5,7 @@ let s:_has_rg                = 0 && executable('rg')
 let s:_has_ag                = 0 && executable('ag')
 let s:_has_ack               = 0 && executable('ack')
 let s:_has_sift              = 0 && executable('sift')
+let s:_has_cgrep             = 1 && executable('cgrep')
 let s:_can_async             = s:_is_nvim || has('job')
 let s:util                   = {}
 let s:util.modifier_mappings = {
@@ -17,11 +18,12 @@ let s:util.modifier_mappings = {
       \ }
 
 let s:util.grepopts = {
-      \ 'rg':   { 'timeout': 40,  'opts': ['--vimgrep'] },
-      \ 'ag':   { 'timeout': 60,  'opts': ['--vimgrep'] },
-      \ 'sift': { 'timeout': 40,  'opts': ['-n', '--column', '--only-matching'] },
-      \ 'ack':  { 'timeout': 120, 'opts': ['-H', '--column', '--nogroup'] },
-      \ 'grep': { 'timeout': 120, 'opts': ['-o', '--line-number', '--byte-offset'], 'pat_flag': ['-E'] }
+      \ 'rg':    { 'timeout': 40,  'opts': ['--vimgrep'] },
+      \ 'ag':    { 'timeout': 60,  'opts': ['--vimgrep'] },
+      \ 'ack':   { 'timeout': 120, 'opts': ['-H', '--column', '--nogroup'] },
+      \ 'sift':  { 'timeout': 40,  'opts': ['-n', '--column', '--only-matching'] },
+      \ 'grep':  { 'timeout': 120, 'opts': ['-o', '--line-number', '--byte-offset'], 'pat_flag': ['-E'] },
+      \ 'cgrep': { 'timeout': 60,  'opts': ['--regex-pcre', '--format="#f:#n:#,"'] }
       \ }
 
 if (s:_has_rg)
@@ -32,6 +34,8 @@ elseif (s:_has_ag)
   let s:util.grepcmd = 'ag'
 elseif (s:_has_ack)
   let s:util.grepcmd = 'ack'
+elseif (s:_has_cgrep)
+  let s:util.grepcmd = 'cgrep'
 else
   let s:util.grepcmd = 'grep'
 endif

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1,5 +1,6 @@
 """"" UTILITY FUNCTIONS
 let s:_is_nvim               = has('nvim')
+let s:_has_curl              = executable('curl')
 let s:_can_async             = s:_is_nvim || has('job')
 let s:util                   = {}
 let s:util.modifier_mappings = {
@@ -138,22 +139,22 @@ fun! s:util.ListLinks()
   while (lnum < limit)
     let line = getline(lnum)
     let col  = 0
-    let len  = len(line)
+    let len  = strlen(line)
 
     while (col < len)
         if (tolower(synIDattr(synID(lnum, 1, 0), 'name')) == 'markdowncode') | break | endif
-        let tcol = match(line[col:], '\](\(#\?[^)]\+\))')
-        let href = tcol > -1 ? -1 : match(line[col:], 'href="\(#\?[^"]\+\)"')
+        let tcol = match(line[col:], '\](\([^)]\+\))')
+        let href = tcol > -1 ? -1 : match(line[col:], 'href="\([^"]\+\)"')
         let html = href > -1
         if ((html && href < 0) || (!html && tcol < 0)) | break | endif
         let col += html ? href : tcol
-        let rgx  = html ? 'href="\(#\?[^"]\+\)"' : '\](\(#\?[^)]\+\))'
+        let rgx  = html ? 'href="\([^"]\+\)"' : '\](\([^)]\+\))'
 
         let matchtext = get(matchlist(line[col:], rgx), 1, -1)
         if (matchtext == -1) | break | endif
 
         call add(links, [lnum, col + (html ? 6 : 2), matchtext])
-        let col += len(matchtext)
+        let col += strlen(matchtext)
     endwhile
 
     let lnum += 1
@@ -178,7 +179,7 @@ fun! s:util.ListIDAnchorLinks()
   while (lnum < limit)
     let line = getline(lnum)
     let col  = 0
-    let len  = len(line)
+    let len  = strlen(line)
 
     while (col < len)
         if (tolower(synIDattr(synID(lnum, 1, 0), 'name')) == 'markdowncode') | break | endif
@@ -190,7 +191,7 @@ fun! s:util.ListIDAnchorLinks()
         if (matchtext == -1) | break | endif
 
         call add(links, [lnum, col, matchtext])
-        let col += len(matchtext)
+        let col += strlen(matchtext)
     endwhile
 
     let lnum += 1
@@ -754,7 +755,7 @@ fun! mkdx#QuickfixDeadLinks(...)
     let dl = len(dead)
 
     call setqflist(dead)
-    if (g:mkdx#settings.links.external.enable && s:_can_async && executable('curl'))
+    if (g:mkdx#settings.links.external.enable && s:_can_async && s:_has_curl)
       call s:util.AsyncDeadExternalToQF(0, total)
     endif
 

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -4,8 +4,9 @@ let s:_has_curl              = executable('curl')
 let s:_has_rg                = 0 && executable('rg')
 let s:_has_ag                = 0 && executable('ag')
 let s:_has_ack               = 0 && executable('ack')
-let s:_has_sift              = 0 && executable('sift')
-let s:_has_cgrep             = 1 && executable('cgrep')
+let s:_has_sift              = 1 && executable('sift')
+let s:_has_cgrep             = 0 && executable('cgrep')
+let s:_has_pt                = 0 && executable('pt')
 let s:_can_async             = s:_is_nvim || has('job')
 let s:util                   = {}
 let s:util.modifier_mappings = {
@@ -18,12 +19,13 @@ let s:util.modifier_mappings = {
       \ }
 
 let s:util.grepopts = {
-      \ 'rg':    { 'timeout': 40,  'opts': ['--vimgrep'] },
-      \ 'ag':    { 'timeout': 60,  'opts': ['--vimgrep'] },
-      \ 'ack':   { 'timeout': 120, 'opts': ['-H', '--column', '--nogroup'] },
-      \ 'sift':  { 'timeout': 40,  'opts': ['-n', '--column', '--only-matching'] },
-      \ 'grep':  { 'timeout': 120, 'opts': ['-o', '--line-number', '--byte-offset'], 'pat_flag': ['-E'] },
-      \ 'cgrep': { 'timeout': 60,  'opts': ['--regex-pcre', '--format="#f:#n:#0"'] }
+      \ 'rg':    { 'timeout': 50,  'opts': ['--vimgrep'] },
+      \ 'ag':    { 'timeout': 50,  'opts': ['--vimgrep'] },
+      \ 'ack':   { 'timeout': 100, 'opts': ['-H', '--column', '--nogroup'] },
+      \ 'sift':  { 'timeout': 100, 'opts': ['-n', '--column', '--only-matching'] },
+      \ 'grep':  { 'timeout': 100, 'opts': ['-o', '--line-number', '--byte-offset'], 'pat_flag': ['-E'] },
+      \ 'cgrep': { 'timeout': 50,  'opts': ['--regex-pcre', '--format="#f:#n:#0"'] },
+      \ 'pt':    { 'timeout': 50,  'opts': ['--nocolor', '--column', '--numbers', '--nogroup'], 'pat_flag': ['-e'] }
       \ }
 
 if (s:_has_rg)
@@ -32,19 +34,21 @@ elseif (s:_has_sift)
   let s:util.grepcmd = 'sift'
 elseif (s:_has_ag)
   let s:util.grepcmd = 'ag'
-elseif (s:_has_ack)
-  let s:util.grepcmd = 'ack'
 elseif (s:_has_cgrep)
   let s:util.grepcmd = 'cgrep'
+elseif (s:_has_ack)
+  let s:util.grepcmd = 'ack'
+elseif (s:_has_pt)
+  let s:util.grepcmd = 'pt'
 else
   let s:util.grepcmd = 'grep'
 endif
 
-let s:_can_vimgrep_fmt = has_key(s:util.grepopts, s:util.grepcmd)
-
 echohl MoreMsg
-echo 's:util.grepcmd =' s:util.grepcmd
+echo s:util.grepcmd
 echohl None
+
+let s:_can_vimgrep_fmt = has_key(s:util.grepopts, s:util.grepcmd)
 
 fun! s:util._(...)
 endfun
@@ -695,18 +699,28 @@ fun! s:util.IdentifyGrepLink(input)
   let lnum  = str2nr(get(parts, 0, 1))
   let cnum  = str2nr(get(parts, 1, 1))
   let matched = get(parts, 2, '')
-  let heof  = s:util.grepcmd == 'cgrep' ? -2 : -1
+  let cgroff  = s:util.grepcmd == 'cgrep' ? -2 : -1
 
-  " echo matched
+  if (index(['pt', 'ag', 'ack'], s:util.grepcmd))
+    let tmp = get(matchlist(matched[(cnum - 1):], '\(id\|name\)="[^"]\+"\|\]([^)]\+)\|^#\{1,6}.*$'), 0, '')
+    let matched = empty(tmp) ? matched : tmp
+  endif
 
-  if (empty(matched))         | return { 'type': 'blank',  'lnum': lnum, 'col': cnum,     'content': '' }              | endif
-  if (matched[0:1] == '](')   | return { 'type': 'link',   'lnum': lnum, 'col': cnum + 2, 'content': matched[2:-2] }   | endif
-  if (matched[0:1] == 'id')   | return { 'type': 'anchor', 'lnum': lnum, 'col': cnum + 4, 'content': matched[4:-2] }   | endif
-  if (matched[0:3] == 'href') | return { 'type': 'link',   'lnum': lnum, 'col': cnum + 6, 'content': matched[6:-2] }   | endif
-  if (matched[0:3] == 'name') | return { 'type': 'anchor', 'lnum': lnum, 'col': cnum + 6, 'content': matched[6:-2] }   | endif
-  if (matched =~ '^#\{1,6} ') | return { 'type': 'header', 'lnum': lnum, 'col': cnum,     'content': matched[0:heof] } | endif
+  if (empty(matched))         | return { 'type': 'blank',  'lnum': lnum, 'col': cnum,     'content': '' }                | endif
+  if (matched[0:1] == '](')   | return { 'type': 'link',   'lnum': lnum, 'col': cnum + 2, 'content': matched[2:-2] }     | endif
+  if (matched[0:1] == 'id')   | return { 'type': 'anchor', 'lnum': lnum, 'col': cnum + 4, 'content': matched[4:-2] }     | endif
+  if (matched[0:3] == 'href') | return { 'type': 'link',   'lnum': lnum, 'col': cnum + 6, 'content': matched[6:-2] }     | endif
+  if (matched[0:3] == 'name') | return { 'type': 'anchor', 'lnum': lnum, 'col': cnum + 6, 'content': matched[6:-2] }     | endif
+  if (matched =~ '^#\{1,6} ') | return { 'type': 'header', 'lnum': lnum, 'col': cnum,     'content': matched[0:cgroff] } | endif
 
   return { 'type': 'unknown', 'lnum': lnum, 'col': cnum, 'content': matched }
+endfun
+
+fun! mkdx#SetGrepCmd(cmd)
+  let s:util.grepcmd = a:cmd
+  echohl MoreMsg
+  echo 's:util.grepcmd =' a:cmd
+  echohl None
 endfun
 
 """"" MAIN FUNCTIONALITY
@@ -755,12 +769,11 @@ fun! s:util.ContextualComplete()
     let start -= 1
   endwhile
 
-  if (start < 0)          | return [0,     []] | endif
   if (line[start] != '#') | return [start, []] | endif
 
   if (s:_is_nvim && s:_can_vimgrep_fmt)
     let hashes = {}
-    let s:util._complete_jid = s:util.Grep({'pattern': '^#{1,6}.*$|(name|id)="[^"]+',
+    let s:util._complete_jid = s:util.Grep({'pattern': '^#{1,6}.*$|(name|id)="[^"]+"',
                                           \ 'each': function(s:util.HeadersAndAnchorsToHashCompletions, [hashes])})
 
     exe 'sleep' . get(s:util.grepopts, s:util.grepcmd, {'timeout': 100}).timeout . 'm'

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -82,6 +82,7 @@ if (g:mkdx#settings.links.fragment.complete)
   setlocal completefunc=mkdx#Complete
   setlocal pumheight=15
   setlocal iskeyword+=\-
+  setlocal completeopt=noinsert,menuone
 endif
 
 if g:mkdx#settings.map.enable == 1

--- a/test/setup.vader
+++ b/test/setup.vader
@@ -22,7 +22,7 @@ Execute (Setup):
       \                                         'default': 'center' } },
       \ 'links':                   { 'external': { 'enable': 0, 'timeout': 3, 'host': '', 'relative': 1,
       \                                            'user_agent':  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/9001.0.0000.000 vim-mkdx/1.5.0' },
-      \                              'fragment': { 'jumplist': 1 } },
+      \                              'fragment': { 'jumplist': 1, 'complete': 1 } },
       \ 'highlight':               { 'enable': 0 }
     \ }
 

--- a/test/teardown.vader
+++ b/test/teardown.vader
@@ -2,5 +2,5 @@ Execute (Teardown):
   let &sw             = g:vim_dev__vader_sw
   let &autoindent     = g:vim_dev__vader_autoindent
   let &ft             = g:vim_dev__vader_ft
-  let g:mkdx#settings = deepcopy(g:vim_dev__vader_settings)
+  let g:mkdx#settings = g:vim_dev__vader_settings
 


### PR DESCRIPTION
Support a variation of grep programs such as `ag`, `pt`, `ack`, `sift`, `cgrep` and `ucg`.
Still only works in Neovim at the moment, in regular Vim the fallback method using Vimscript will be used instead (should be fine upto about 1k+ line markdown files).

In the rare case that no grep program is found, the Vimscript fallback will also be used.