### PR TITLE
Feature/async headers to quickfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ settings and examples with default mappings.
         <li><a href="#unmapping-functionality-using-nop">Unmapping functionality using <code>&lt;Nop&gt;</code></a></li>
         <li><a href="#unmapping-functionality-using-plug">Unmapping functionality using <code>&lt;Plug&gt;</code></a></li>
     </ul></li>
+    <li><a href="#supported-grep-programs">Supported <code>grep</code> programs</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#roadmap">Roadmap</a></li>
     <li><a href="#changelog">Changelog</a><ul>
@@ -1197,6 +1198,21 @@ The corresponding `<Plug>` is called `<Plug>(mkdx-checkbox-next)`. To disable it
 ```viml
 map <Plug> <Plug>(mkdx-checkbox-next)
 ```
+
+# Supported `grep` programs
+
+When your vim `has('job')` or `has('nvim')`, mkdx will look for a grep program, the following are recognized:
+
+- [`rg`](https://github.com/BurntSushi/ripgrep)
+- [`ag`](https://github.com/ggreer/the_silver_searcher)
+- [`cgrep`](https://github.com/awgn/cgrep)
+- [`ack`](https://github.com/beyondgrep/ack2)
+- [`pt`](https://github.com/monochromegane/the_platinum_searcher)
+- [`ucg`](https://github.com/gvansickle/ucg)
+- [`sift`](https://github.com/svent/sift)
+
+The listed programs are searched in order, if a program is found, it will be used in [various](#insert-mode-fragment-completion) [different](#jump-to-header) places.
+This will prevent your editor from freezing and it'll be blazing fast compared to the builtin Vimscript fallbacks.
 
 # Contributing
 

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -84,6 +84,7 @@ fun! s:util.JumpToHeader(link, hashes, jid, stream, ...)
         normal! m'0
       endif
       call cursor(item.lnum, 0)
+      redraw
       break
     endif
   endfor

--- a/test/setup.vader
+++ b/test/setup.vader
@@ -1,12 +1,12 @@
 Execute (Setup):
-  let g:vim_dev__vader_ft = &ft
-  setf markdown
-  let g:vim_dev__vader_sw = &sw
-  set sw=4
-  let g:vim_dev__vader_autoindent = &autoindent
-  set autoindent
-  
   if (!exists('g:vim_dev__vader_settings'))
+    let g:vim_dev__vader_ft = &ft
+    setf markdown
+    let g:vim_dev__vader_sw = &sw
+    set sw=4
+    let g:vim_dev__vader_autoindent = &autoindent
+    set autoindent
+
     let g:vim_dev__vader_settings = deepcopy(g:mkdx#settings)
     let g:mkdx#settings = {
         \ 'image_extension_pattern': 'a\?png\|jpe\?g\|gif',
@@ -26,5 +26,7 @@ Execute (Setup):
         \                              'fragment': { 'jumplist': 1, 'complete': 1 } },
         \ 'highlight':               { 'enable': 0 }
       \ }
+
+    call mkdx#testing(1)
   endif
 

--- a/test/teardown.vader
+++ b/test/teardown.vader
@@ -9,3 +9,4 @@ Execute (Teardown):
   unlet g:vim_dev__vader_ft
   unlet g:vim_dev__vader_settings
 
+  call mkdx#testing(0)


### PR DESCRIPTION
Jump to quickfix async when possible, falls back to good ol' Vimscript approach.
Tests will fail when async features are available, added setup / teardown guards that temporarily disables these features and tests the builtin methods instead.