### PR TITLE
Resolves #38 - always set autoindent

### DIFF
--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -136,6 +136,7 @@ if g:mkdx#settings.map.enable == 1
 
   if (g:mkdx#settings.enter.enable)
     setlocal formatoptions-=r
+    setlocal autoindent
     imap <buffer><silent> <Cr> <Plug>(mkdx-enter)
 
     if (!hasmapto('<Plug>(mkdx-o)') && g:mkdx#settings.enter.o)


### PR DESCRIPTION
This small patch fixes #38.

Vim does not have `autoindent` enabled by default, from `:h autoindent`:

```help
			*'autoindent'* *'ai'* *'noautoindent'* *'noai'*
'autoindent' 'ai'	boolean	(default off)
```

The same documentation in Nvim `:h autoindent`:

```help
			*'autoindent'* *'ai'* *'noautoindent'* *'noai'*
'autoindent' 'ai'	boolean	(default on)
```

The tests kept working because they assumed `&formatoptions` to be `1` by setting it before the tests and restoring it afterwards.