### PR TITLE
Feature/table highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1087,15 +1087,8 @@ let g:mkdx#settings = { 'toc': { 'details': { 'summary': 'Click to expand {{toc.
 
 ## `g:mkdx#settings.highlight.enable`
 
-This setting enables state-specific highlighting for checkboxes.
-It will also override the default markdown syntax highlighting scheme to better accomodate the colors used.
+This setting enables state-specific highlighting for checkboxes and tables.
 The highlighting is linked to the `gitcommit*` family of highlight groups (and Comment for list items), full list:
-
-- `Comment` is used for list items, e.g. items starting with `-`, `*`, `1.`
-- `gitcommitUnmergedFile` is used for empty checkboxes: `[ ]`
-- `gitcommitBranch` is used for pending / in-progress checkboxes: `[-]`
-- `gitcommitSelectedFile` is used for completed checkboxes: `[x]`
-
 If you want to change the highlighting groups, `link` them to different groups:
 
 ```viml
@@ -1114,6 +1107,8 @@ highlight link mkdxListItem jsOperator
 Note: syntax highlighting is opt-in _by default_. This means you must explicitly enable this feature to use it.
 The reason behind this is that this plugin is not a syntax plugin and maybe you are already using one that does such a thing in a way that works better for you.
 You can see it in action in the [Completing checkboxes / checklists](#completing-checkboxes--checklists) examples.
+
+This setting is [auto updated](#gmkdxsettingsauto_updateenable) when available.
 
 ```viml
 " :h mkdx-setting-highlight-enable
@@ -1138,6 +1133,7 @@ The following settings are automatically updated:
 - [`g:mkdx#settings.fold.enable`](#gmkdxsettingsfoldenable)
 - [`g:mkdx#settings.fold.components`](#gmkdxsettingsfoldcomponents)
 - [`g:mkdx#settings.links.fragment.complete`](#gmkdxsettingslinksfragmentcomplete)
+- [`g:mkdx#settings.highlight.enable`](#gmkdxsettingshighlightenable)
 
 ```viml
 " :h mkdx-setting-auto-update-enable

--- a/after/syntax/markdown/mkdx.vim
+++ b/after/syntax/markdown/mkdx.vim
@@ -1,27 +1,52 @@
 if (exists('g:mkdx#settings') && g:mkdx#settings.highlight.enable != 1) | finish | endif
 
+" https://github.com/mattly/vim-markdown-enhancements/blob/master/after/syntax/markdown.vim
+" the table highlighting is taken from this repo, which is now read-only,
+" thanks @mattly for your contribution ;)
+syn region  mkdxTable start="^\%(\[.*\]\n\)\{}.*|.*\n[-|\:\. ]\+$" end="\%(\n\[.*\]\n\)\{}\ze\n[^|]\+\n$" keepend contains=mkdxTableHeader,mkdxTableHeadDelimiter,mkdxTableDelimiter,mkdxTableCaption
+syn match   mkdxTableDelimiter "|" contained
+syn match   mkdxTableAlign "[\.:]" contained
+syn region  mkdxTableHeader start="^\zs.*\ze\n[-|\:\. ]\+$" end="$" nextgroup=mkdxTableHeadDelimiter contained contains=mkdxTableDelimiter
+syn match   mkdxTableHeadDelimiter "^[-|\:\.\ ]\+$" contained contains=mkdxTableDelimiter,mkdxTableAlign
+syn region  mkdxTableCaption matchgroup=mkdxTableCaptionDelimiter start="^\[" end="\]$" keepend contained
+syn match   mkdxListItem '^[ \t]*\([0-9.]\+\|[-*]\) '
+syn match   mkdxCheckboxEmpty '\[ \]'
+syn match   mkdxCheckboxPending '\[-\]'
+syn match   mkdxCheckboxComplete '\[x\]'
+syn match   mkdxTildeFence '^[ \t]*\~\~\~\w*'
+
+if hlexists('Constant')
+  highlight default link mkdxTableHeader Constant
+endif
+
+if hlexists('Delimiter')
+  highlight default link mkdxTableDelimiter        Delimiter
+  highlight default link mkdxTableHeadDelimiter    Delimiter
+  highlight default link mkdxTableCaptionDelimiter Delimiter
+endif
+
+if hlexists('Identifier')
+  highlight default link mkdxTableAlign Identifier
+endif
+
 if hlexists('Comment')
-  syntax match mkdxListItem '^[ \t]*\([0-9.]\+\|[-*]\) '
-  highlight default link mkdxListItem Comment
+  highlight default link mkdxListItem     Comment
+  highlight default link mkdxTableCaption Comment
 endif
 
 if hlexists('gitcommitUnmergedFile')
-  syntax match mkdxCheckboxEmpty '\[ \]'
   highlight default link mkdxCheckboxEmpty gitcommitUnmergedFile
 endif
 
 if hlexists('gitcommitBranch')
-  syntax match mkdxCheckboxPending '\[-\]'
   highlight default link mkdxCheckboxPending gitcommitBranch
 endif
 
 if hlexists('gitcommitSelectedFile')
-  syntax match mkdxCheckboxComplete '\[x\]'
   highlight default link mkdxCheckboxComplete gitcommitSelectedFile
 endif
 
 if hlexists('markdownCodeDelimiter')
-  syntax match mkdxTildeFence '^[ \t]*\~\~\~\w*'
   highlight default link mkdxTildeFence markdownCodeDelimiter
 
   if hlexists('markdownCode')

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1,14 +1,7 @@
 """"" UTILITY FUNCTIONS
 let s:_is_nvim               = has('nvim')
 let s:_has_curl              = executable('curl')
-let s:_has_rg                = 1 && executable('rg')
-let s:_has_ag                = s:_has_rg    || executable('ag')
-let s:_has_cgrep             = s:_has_ag    || executable('cgrep')
-let s:_has_ack               = s:_has_cgrep || executable('ack')
-let s:_has_pt                = s:_has_ack   || executable('pt')
-let s:_has_ucg               = s:_has_pt    || executable('ucg')
-let s:_has_sift              = s:_has_ucg   || executable('sift')
-let s:_can_async             = s:_is_nvim   || has('job')
+let s:_can_async             = s:_is_nvim || has('job')
 let s:util                   = {}
 let s:util.modifier_mappings = {
       \ 'C': 'ctrl',
@@ -38,24 +31,13 @@ let s:util.grepopts = {
       \            'opts': ['-o', '--line-number', '--byte-offset'], 'pat_flag': ['-E'] }
       \ }
 
-if (s:_has_rg)
-  let s:util.grepcmd = 'rg'
-elseif (s:_has_ag)
-  let s:util.grepcmd = 'ag'
-elseif (s:_has_cgrep)
-  let s:util.grepcmd = 'cgrep'
-elseif (s:_has_ack)
-  let s:util.grepcmd = 'ack'
-elseif (s:_has_pt)
-  let s:util.grepcmd = 'pt'
-elseif (s:_has_ucg)
-  let s:util.grepcmd = 'ucg'
-elseif (s:_has_sift)
-  let s:util.grepcmd = 'sift'
-else
-  let s:util.grepcmd = executable('cgrep') ? 'cgrep' : 'grep'
-endif
+fun! s:util.set_grep()
+  for tool in ['rg', 'ag', 'cgrep', 'ack', 'pt', 'ucg', 'sift', 'ggrep', 'grep']
+    if (executable(tool)) | return tool | endif
+  endfor
+endfun
 
+let s:util.grepcmd     = s:util.set_grep()
 let s:_can_vimgrep_fmt = has_key(s:util.grepopts, s:util.grepcmd)
 let s:_testing         = 0
 

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -224,6 +224,29 @@ fun! s:util.ToggleEnter(old, new)
   endif
 endfun
 
+let s:util.mkdx_loadpath = get(filter(split(&rtp, ','), {idx, plugin -> match(plugin, 'mkdx/\?$') > -1}), 0, '')
+let s:util.mkdx_loadpath = !empty(s:util.mkdx_loadpath) ? substitute(s:util.mkdx_loadpath, '/\+$', '', 'g') : s:util.mkdx_loadpath
+let s:util.syn_loadpath  = join([s:util.mkdx_loadpath, 'after/syntax/markdown/mkdx.vim'], '/')
+
+fun! s:util.ToggleHighlight(old, new)
+  if (a:new)
+    exe 'so ' . s:util.syn_loadpath
+  else
+    highlight clear mkdxTable
+    highlight clear mkdxTableDelimiter
+    highlight clear mkdxTableAlign
+    highlight clear mkdxTableHeader
+    highlight clear mkdxTableHeadDelimiter
+    highlight clear mkdxTableCaption
+    highlight clear mkdxListItem
+    highlight clear mkdxCheckboxEmpty
+    highlight clear mkdxCheckboxPending
+    highlight clear mkdxCheckboxComplete
+    highlight clear mkdxTildeFence
+    setf markdown
+  endif
+endfun
+
 fun! s:util.UpdateHeaders(old, new)
   let skip = 0
 
@@ -253,7 +276,8 @@ let s:util.updaters = {
       \ 'g:mkdx#settings.fold.components': s:util.UpdateFolds,
       \ 'g:mkdx#settings.fold.enable': s:util.ToggleFolds,
       \ 'g:mkdx#settings.links.fragment.complete': s:util.ToggleCompletions,
-      \ 'g:mkdx#settings.enter.enable': s:util.ToggleEnter
+      \ 'g:mkdx#settings.enter.enable': s:util.ToggleEnter,
+      \ 'g:mkdx#settings.highlight.enable': s:util.ToggleHighlight
       \ }
 
 fun! s:util.validate(value, validations)

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -13,22 +13,14 @@ let s:util.modifier_mappings = {
       \ }
 
 let s:util.grepopts = {
-      \ 'rg':    { 'timeout': 35,
-      \            'opts': ['--vimgrep', '-o'] },
-      \ 'ag':    { 'timeout': 35,
-      \            'opts': ['--vimgrep'] },
-      \ 'cgrep': { 'timeout': 35,
-      \            'opts': ['--regex-pcre', '--format="#f:#n:#0"'] },
-      \ 'ack':   { 'timeout': 35,
-      \            'opts': ['-H', '--column', '--nogroup'] },
-      \ 'pt':    { 'timeout': 35,
-      \            'opts': ['--nocolor', '--column', '--numbers', '--nogroup'], 'pat_flag': ['-e'] },
-      \ 'ucg':   { 'timeout': 35,
-      \            'opts': ['--column'] },
-      \ 'sift':  { 'timeout': 35,
-      \            'opts': ['-n', '--column', '--only-matching'] },
-      \ 'grep':  { 'timeout': 35,
-      \            'opts': ['-o', '--line-number', '--byte-offset'], 'pat_flag': ['-E'] }
+      \ 'rg':    { 'opts': ['--vimgrep', '-o'] },
+      \ 'ag':    { 'opts': ['--vimgrep'] },
+      \ 'cgrep': { 'opts': ['--regex-pcre', '--format="#f:#n:#0"'] },
+      \ 'ack':   { 'opts': ['-H', '--column', '--nogroup'] },
+      \ 'pt':    { 'opts': ['--nocolor', '--column', '--numbers', '--nogroup'], 'pat_flag': ['-e'] },
+      \ 'ucg':   { 'opts': ['--column'] },
+      \ 'sift':  { 'opts': ['-n', '--column', '--only-matching'] },
+      \ 'grep':  { 'opts': ['-o', '--line-number', '--byte-offset'], 'pat_flag': ['-E'] }
       \ }
 
 fun! s:util.set_grep()
@@ -852,7 +844,7 @@ fun! s:util.IsInsideLink()
 endfun
 
 fun! s:util.Grep(...)
-  let grepopts = extend({'opts': [], 'timeout': 100, 'pat_flag': []}, get(s:util.grepopts, s:util.grepcmd, {}))
+  let grepopts = extend({'opts': [], 'timeout': 50, 'pat_flag': []}, get(s:util.grepopts, s:util.grepcmd, {}))
   let options  = extend({'pattern': 'href="[^"]+"|\]\([^\(]+\)|^#{1,6}.*\$',
                       \  'done': s:util._, 'each': s:util._, 'file': expand('%')},
                       \ get(a:000, 0, {}))
@@ -997,11 +989,11 @@ fun! s:util.ContextualComplete()
 
   if (!s:_testing && s:_can_vimgrep_fmt)
     let hashes = {}
-    let opts = extend({'pattern': '^#{1,6}.*$|(name|id)="[^"]+"'}, get(s:util.grepopts, s:util.grepcmd, {}))
+    let opts = extend({'pattern': '^#{1,6}.*$|(name|id)="[^"]+"', 'timeout': 50}, get(s:util.grepopts, s:util.grepcmd, {}))
     let opts['each'] = function(s:util.HeadersAndAnchorsToHashCompletions, [hashes])
     call s:util.Grep(opts)
 
-    exe 'sleep' . get(s:util.grepopts, s:util.grepcmd, {'timeout': 100}).timeout . 'm'
+    exe 'sleep' . opts.timeout . 'm'
 
     return [start, []]
   else

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -62,6 +62,13 @@ CONTENTS                                                         *mkdx-contents*
         `mkdxCheckboxEmpty`
         `mkdxCheckboxPending`
         `mkdxCheckboxComplete`
+        `mkdxTable`
+        `mkdxTableDelimiter`
+        `mkdxTableAlign`
+        `mkdxTableHeader`
+        `mkdxTableHeaderDelimiter`
+        `mkdxTableCaption`
+        `mkdxTableCaptionDelimiter`
 
     Plugs
         <Plug>(mkdx-ctrl-n-compl)
@@ -243,6 +250,13 @@ for functions. Below is a list of all helptags:
     - |mkdx-highlight-checkbox-empty|
     - |mkdx-highlight-checkbox-pending|
     - |mkdx-highlight-checkbox-complete|
+    - |mkdx-highlight-table|
+    - |mkdx-highlight-table-delimiter|
+    - |mkdx-highlight-table-align|
+    - |mkdx-highlight-table-header|
+    - |mkdx-highlight-table-header-delimiter|
+    - |mkdx-highlight-table-caption|
+    - |mkdx-highlight-table-caption-delimiter|
 
 - |mkdx-plugs|
     - |mkdx-plug-ctrl-n-compl|
@@ -778,10 +792,10 @@ by default.
 ==============================================================================
 `g:mkdx#settings.highlight.enable = 0`             *mkdx-setting-highlight-enable*
 
-Enables state-specific highlighting for checkboxes.
-Setting this will override the syntax highlighting for list item markers (`-`,
-`*` or `1.1.` for example) in addition to providing highlighting for
-checkboxes. The scheme goes as follows:
+Enables state-specific highlighting for checkboxes and generic highlighting
+for tables. Setting this will override the syntax highlighting for list item
+markers (`-`, `*` or `1.1.` for example) in addition to providing highlighting for
+checkboxes and tables. The scheme goes as follows:
 
 - Empty / unstarted checkboxes are colored red
 - In progress checkboxes are colored orange
@@ -893,6 +907,39 @@ To override the colors for a highlight group, see: |highlight|.
 `mkdxCheckboxComplete`                          *mkdx-highlight-checkbox-complete*
 
     `highlight default link mkdxCheckboxComplete gitcommitSelectedFile`
+
+==============================================================================
+`mkdxTable`                                                 *mkdx-highlight-table*
+
+==============================================================================
+`mkdxTableDelimiter`                              *mkdx-highlight-table-delimiter*
+
+  `highlight default link mkdxTableDelimiter Delimiter`
+
+==============================================================================
+`mkdxTableAlign`                                      *mkdx-highlight-table-align*
+
+  `highlight default link mkdxTableAlign Identifier`
+
+==============================================================================
+`mkdxTableHeader`                                    *mkdx-highlight-table-header*
+
+  `highlight default link mkdxTableHeader Constant`
+
+==============================================================================
+`mkdxTableHeadDelimiter`                     *mkdx-highlight-table-head-delimiter*
+
+  `highlight default link mkdxTableHeadDelimiter Delimiter`
+
+==============================================================================
+`mkdxTableCaption`                                  *mkdx-highlight-table-caption*
+
+  `highlight default link mkdxTableCaption Comment`
+
+==============================================================================
+`mkdxTableCaptionDelimiter`               *mkdx-highlight-table-caption-delimiter*
+
+  `highlight default link mkdxTableCaptionDelimiter Delimiter`
 
 ==============================================================================
 PLUGS                                                               *mkdx-plugs*


### PR DESCRIPTION
Adds highlighting for markdown tables:
![image](https://user-images.githubusercontent.com/3225058/39951667-420fff4c-558c-11e8-9080-cf41d35907d4.png)

credits to [@mattly](https://github.com/mattly) for a tiny part of his [plugins' syntax file](https://github.com/mattly/vim-markdown-enhancements/blob/master/after/syntax/markdown.vim).

`g:mkdx#settings.highlight.enable` is now also auto-updated, mkdx-specific highlighting can be enabled / disabled on the fly now.
