### PR TITLE
Feature/strikethrough style

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ settings and examples with default mappings.
         <li><a href="#gmkdxsettingstokensfence"><code>g:mkdx#settings.tokens.fence</code></a></li>
         <li><a href="#gmkdxsettingstokensitalic"><code>g:mkdx#settings.tokens.italic</code></a></li>
         <li><a href="#gmkdxsettingstokensbold"><code>g:mkdx#settings.tokens.bold</code></a></li>
+        <li><a href="#gmkdxsettingstokensstrike"><code>g:mkdx#settings.tokens.strike</code></a></li>
         <li><a href="#gmkdxsettingstokenslist"><code>g:mkdx#settings.tokens.list</code></a></li>
         <li><a href="#gmkdxsettingstableheader_divider"><code>g:mkdx#settings.table.header_divider</code></a></li>
         <li><a href="#gmkdxsettingstabledivider"><code>g:mkdx#settings.table.divider</code></a></li>
@@ -923,6 +924,11 @@ let g:mkdx#settings = { 'tokens': { 'italic': '*' } }
 ## `g:mkdx#settings.tokens.bold`
 
 This token is used for bolding the current word under the cursor or a visual selection of text.
+See [this section](#wrap-as-bold--italic--inline-code--strikethrough) for more details.
+
+## `g:mkdx#settings.tokens.strike`
+
+This token is used for striking the current word under the cursor or a visual selection of text.
 See [this section](#wrap-as-bold--italic--inline-code--strikethrough) for more details.
 
 ```viml

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1176,7 +1176,21 @@ fun! mkdx#WrapText(...)
   let x = get(a:000, 2, w)
   let a = get(a:000, 3, '')
 
-  call s:util.WrapSelectionOrWord(m, w, x, a)
+  call s:util.WrapSelectionOrWord(m, w, x)
+
+  if (a != '')
+    silent! call repeat#set("\<Plug>(" . a . ")")
+  endif
+endfun
+
+fun! mkdx#WrapStrike(...)
+  let m = get(a:000, 0, 'n')
+  let a = get(a:000, 1, '')
+  let e = !empty(g:mkdx#settings.tokens.strike)
+  let s = e ? g:mkdx#settings.tokens.strike : '<strike>'
+  let z = e ? g:mkdx#settings.tokens.strike : '</strike>'
+
+  call s:util.WrapSelectionOrWord(m, s, z)
 
   if (a != '')
     silent! call repeat#set("\<Plug>(" . a . ")")

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -40,6 +40,7 @@ CONTENTS                                                         *mkdx-contents*
         `g:mkdx#settings.tokens.fence`
         `g:mkdx#settings.tokens.italic`
         `g:mkdx#settings.tokens.bold`
+        `g:mkdx#settings.tokens.strike`
         `g:mkdx#settings.tokens.list`
         `g:mkdx#settings.table.header_divider`
         `g:mkdx#settings.table.divider`
@@ -167,6 +168,8 @@ CONTENTS                                                         *mkdx-contents*
         mkdx#InsertCtrlPHandler()
         mkdx#CompleteLink()
         mkdx#fold()
+        mkdx#WrapText()
+        mkdx#WrapStrike()
 
     Errors
        Type
@@ -238,6 +241,7 @@ for functions. Below is a list of all helptags:
     - |mkdx-setting-tokens-fence|
     - |mkdx-setting-tokens-italic|
     - |mkdx-setting-tokens-bold|
+    - |mkdx-setting-tokens-strike|
     - |mkdx-setting-tokens-list|
     - |mkdx-setting-table-header-divider|
     - |mkdx-setting-table-divider|
@@ -391,6 +395,7 @@ at the bottom of every setting section. The default settings hash:
     `      \ 'map':                     { 'prefix': '<leader>', 'enable': 1 },`
     `      \ 'tokens':                  { 'enter':  ['-', '*', '>'],`
      `     \                              'bold':   '**', 'italic': '*',`
+     `     \                              'strike': '',`
     `      \                              'list':   '-',  'fence':  '',`
         `  \                              'header': '#' },`
     `      \ 'checkbox':                { 'toggles': [' ', '-', 'x'],`
@@ -471,6 +476,7 @@ s:defaults.tokens.header             `=>` g:mkdx#header_style
 s:defaults.tokens.enter              `=>` g:mkdx#list_tokens
 s:defaults.tokens.fence              `=>` g:mkdx#fence_style
 s:defaults.tokens.bold               `=>` g:mkdx#bold_token
+s:defaults.tokens.strike             `=>`
 s:defaults.tokens.italic             `=>` g:mkdx#italic_token
 s:defaults.tokens.list               `=>` g:mkdx#list_token
 s:defaults.enter.enable              `=>` g:mkdx#enhance_enter
@@ -491,7 +497,7 @@ s:defaults.highlight.enable          `=>`
 Check external links as well as absolute and relative paths aside from
 fragment links. Requires Neovim |job-control| or Regular vim |job|.
 
-The following CURL command will be run in the background:
+The following CURL command will be executed in the background:
 
 `curl -L -I -s --no-keepalive -o /dev/null \`
      `-m [g:mkdx#settings.links.external.timeout] -w "%{http_code}"' \`
@@ -682,6 +688,12 @@ text in italic style.
 
 Token used by |mkdx-plug-text-bold-n| and |mkdx-plug-text-bold-v| to wrap
 text in bold style.
+
+==============================================================================
+`g:mkdx#settings.tokens.strike = ''`                  *mkdx-setting-tokens-strike*
+
+Token used by |mkdx-function-wrap-strike| to wrap text with strike tags.
+When empty, `<strike></strike>` will be used to wrap the selected content.
 
 ==============================================================================
 `g:mkdx#settings.tokens.list = '-'`                     *mkdx-setting-tokens-list*
@@ -2169,6 +2181,34 @@ There are two kinds of folds that mkdx understands:
 
 Folding can be disabled for {fence} and {toc} individually by changing
 |mkdx-setting-fold-components|.
+
+==============================================================================
+mkdx#WrapText([{mode}[, {start}[, {end}[, {plug}]]]])  *mkdx-function-wrap-text*
+
+Wraps text based on {mode}, when omitted, this defaults to 'n' and the current
+word under the cursor will be wrapped with {start} and {end}.
+
+{mode} can be `'n'` or `'v'` for 'normal' and 'visual' mode respectively.
+In visual mode, the selection will be wrapped. This also works for multi-line
+selections.
+
+If {start} is omitted, it defaults to an empty string.
+{end} defaults to {start}. when omitted.
+
+When {plug} is supplied and repeat.vim is installed, the function will call:
+
+`   silent! repeat#set("\<Plug>(" . ` {plug} ` . ")")`
+
+The {start}, {end} and {plug} arguments must be string values.
+
+==============================================================================
+mkdx#WrapStrike([{mode}[, {plug}]])                  *mkdx-function-wrap-strike*
+
+Wraps |mkdx-function-wrap-text| specifically for wrapping strikethrough style.
+See |mkdx-setting-tokens-stike| for more details. Both arguments are passed to
+`mkdx#WrapText`. When {mode} is omitted it defaults to 'n' and the current
+word under the cursor will be wrapped. When {plug} is omitted, it defaults to
+an empty string.
 
 ==============================================================================
 |ERRORS|                                                             *mkdx-errors*

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -5,7 +5,7 @@ let s:defaults          = {
       \ 'enter':                   { 'enable': 1, 'shift': 0, 'malformed': 1, 'o': 1, 'shifto': 1 },
       \ 'map':                     { 'prefix': '<leader>', 'enable': 1 },
       \ 'tokens':                  { 'enter': ['-', '*', '>'], 'bold': '**', 'italic': '*',
-      \                              'list': '-', 'fence': '', 'header': '#' },
+      \                              'list': '-', 'fence': '', 'header': '#', 'strike': '' },
       \ 'checkbox':                { 'toggles': [' ', '-', 'x'], 'update_tree': 2, 'initial_state': ' ' },
       \ 'toc':                     { 'text': 'TOC', 'list_token': '-', 'position': 0,
       \                              'details': { 'enable': 0, 'summary': 'Click to expand {{toc.text}}' } },
@@ -66,11 +66,11 @@ noremap         <silent> <Plug>(mkdx-gen-or-upd-toc)     :call      mkdx#Generat
 noremap         <silent> <Plug>(mkdx-text-italic-n)      :<C-U>call mkdx#WrapText('n', g:mkdx#settings.tokens.italic, g:mkdx#settings.tokens.italic, 'mkdx-text-italic-n')<Cr>
 noremap         <silent> <Plug>(mkdx-text-bold-n)        :<C-U>call mkdx#WrapText('n', g:mkdx#settings.tokens.bold, g:mkdx#settings.tokens.bold, 'mkdx-text-bold-n')<Cr>
 noremap         <silent> <Plug>(mkdx-text-inline-code-n) :<C-U>call mkdx#WrapText('n', '`', '`', 'mkdx-text-inline-code-n')<Cr>
-noremap         <silent> <Plug>(mkdx-text-strike-n)      :<C-U>call mkdx#WrapText('n', '<strike>', '</strike>', 'mkdx-text-strike-n')<Cr>
+noremap         <silent> <Plug>(mkdx-text-strike-n)      :<C-U>call mkdx#WrapStrike('n', 'mkdx-text-strike-n')<Cr>
 noremap         <silent> <Plug>(mkdx-text-italic-v)      :<C-U>call mkdx#WrapText('v', g:mkdx#settings.tokens.italic, g:mkdx#settings.tokens.italic)<Cr>
 noremap         <silent> <Plug>(mkdx-text-bold-v)        :<C-U>call mkdx#WrapText('v', g:mkdx#settings.tokens.bold, g:mkdx#settings.tokens.bold)<Cr>
 noremap         <silent> <Plug>(mkdx-text-inline-code-v) :<C-U>call mkdx#WrapText('v', '`', '`')<Cr>
-noremap         <silent> <Plug>(mkdx-text-strike-v)      :<C-U>call mkdx#WrapText('v', '<strike>', '</strike>')<Cr>
+noremap         <silent> <Plug>(mkdx-text-strike-v)      :<C-U>call mkdx#WrapStrike('v')<Cr>
 noremap         <silent> <Plug>(mkdx-toggle-to-kbd-n)    :call      mkdx#ToggleToKbd()<Cr>
 noremap         <silent> <Plug>(mkdx-toggle-to-kbd-v)    :<C-U>call mkdx#ToggleToKbd('v')<Cr>
 noremap         <silent> <Plug>(mkdx-shift-o)            :<C-U>call mkdx#ShiftOHandler()<Cr>

--- a/test/setup.vader
+++ b/test/setup.vader
@@ -11,7 +11,7 @@ Execute (Setup):
         \ 'enter':                   { 'enable': 1, 'shift': 0, 'malformed': 1, 'o': 1, 'shifto': 1 },
         \ 'map':                     { 'prefix': '<leader>', 'enable': 1 },
         \ 'tokens':                  { 'enter': ['-', '*', '>'], 'bold': '**', 'italic': '*',
-        \                              'list': '-', 'fence': '', 'header': '#' },
+        \                              'list': '-', 'fence': '', 'header': '#', 'strike': '' },
         \ 'checkbox':                { 'toggles': [' ', '-', 'x'], 'update_tree': 2, 'initial_state': ' ' },
         \ 'toc':                     { 'text': 'TOC', 'list_token': '-', 'position': 0,
         \                              'details': { 'enable': 0, 'summary': 'Click to expand {{toc.text}}' } },


### PR DESCRIPTION
Related to #49.
Allows customizing the strikethrough style. This used to be hardcoded with `<strike>` tags but now uses a setting: `g:mkdx#settings.tokens.strike`.