### PR TITLE
Feature/toc update on write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 doc/tags
-test.md
+test*.md
 .vimrc-test

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ settings and examples with default mappings.
         <li><a href="#gmkdxsettingsentermalformed"><code>g:mkdx#settings.enter.malformed</code></a></li>
         <li><a href="#gmkdxsettingstoctext"><code>g:mkdx#settings.toc.text</code></a></li>
         <li><a href="#gmkdxsettingstoclist_token"><code>g:mkdx#settings.toc.list_token</code></a></li>
+        <li><a href="#gmkdxsettingstocupdate_on_write"><code>g:mkdx#settings.toc.update_on_write</code></a></li>
         <li><a href="#gmkdxsettingstocposition"><code>g:mkdx#settings.toc.position</code></a></li>
         <li><a href="#gmkdxsettingstocdetailsenable"><code>g:mkdx#settings.toc.details.enable</code></a></li>
         <li><a href="#gmkdxsettingstocdetailssummary"><code>g:mkdx#settings.toc.details.summary</code></a></li>
@@ -631,6 +632,7 @@ let g:mkdx#settings = {
       \                              'update_tree': 2,
       \                              'initial_state': ' ' },
       \ 'toc':                     { 'text': "TOC", 'list_token': '-',
+      \                              'update_on_write': 0,
       \                              'position': 0,
       \                              'details': {
       \                                 'enable': 0,
@@ -1116,6 +1118,20 @@ Defines the list token to use in the generated TOC.
 ```viml
 " :h mkdx-setting-toc-list-token
 let g:mkdx#settings = { 'toc': { 'list_token': '-' } }
+```
+
+## `g:mkdx#settings.toc.update_on_write`
+
+As easy as it is to update the table of contents manually, [it is just as easy to forget](https://github.com/SidOfc/mkdx/search?q=update+toc&type=Commits) :)
+This setting is disabled by default, set it to `1` to enable it and never worry about updating your TOC ever again.
+When the TOC hasn't yet been generated and [`g:mkdx#settings.toc.position`](#gmkdxsettingstocposition) isn't `0`, the TOC will be generated at given position (or as the last header of the document if there aren't enough headers).
+Otherwise, you will first have to generate the TOC once manually in the desired position and then it will be updated too.
+
+**Note:** this only works if your vim `has('autocmd')`.
+
+```viml
+" :h mkdx-setting-toc-update-on-write
+let g:mkdx#settings = { 'toc': { 'save_on_write': 0 } }
 ```
 
 ## `g:mkdx#settings.toc.position`

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1444,6 +1444,16 @@ fun! mkdx#EnterHandler()
   return "\n"
 endfun
 
+fun! mkdx#BeforeWrite()
+  if (g:mkdx#settings.toc.update_on_write != 0)
+    if (s:util.GetTOCPositionAndStyle()[0] > -1)
+      call mkdx#UpdateTOC()
+    elseif (g:mkdx#settings.toc.position > 0)
+      call mkdx#GenerateTOC()
+    endif
+  end
+endfun
+
 fun! mkdx#GenerateOrUpdateTOC()
   silent! call repeat#set("\<Plug>(mkdx-gen-or-upd-toc)")
 

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -52,6 +52,7 @@ CONTENTS                                                         *mkdx-contents*
         `g:mkdx#settings.toc.text`
         `g:mkdx#settings.toc.list_token`
         `g:mkdx#settings.toc.position`
+        `g:mkdx#settings.toc.update_on_write`
         `g:mkdx#settings.toc.details.enable`
         `g:mkdx#settings.toc.details.summary`
         `g:mkdx#settings.highlight.enable`
@@ -254,6 +255,7 @@ for functions. Below is a list of all helptags:
     - |mkdx-setting-toc-text|
     - |mkdx-setting-toc-list-token|
     - |mkdx-setting-toc-position|
+    - |mkdx-setting-toc-update-on-write|
     - |mkdx-setting-toc-details-enable|
     - |mkdx-setting-toc-details-summary|
     - |mkdx-setting-highlight-enable|
@@ -404,6 +406,7 @@ at the bottom of every setting section. The default settings hash:
     `      \ 'toc':                     { 'text':       "TOC",`
     `      \                              'list_token': '-',`
     `      \                              'position':   0,`
+    `      \                              'update_on_write':   0,`
     `      \                              'details':    {`
     `      \                                 'enable':  0,`
     `      \                                 'summary': '{{toc.text}}'`
@@ -487,6 +490,7 @@ s:defaults.enter.shift               `=>`
 s:defaults.toc.list_token            `=>` g:mkdx#toc_list_token
 s:defaults.toc.text                  `=>` g:mkdx#toc_text
 s:defaults.toc.position              `=>`
+s:defaults.toc.update_on_write       `=>`
 s:defaults.toc.details.enable        `=>`
 s:defaults.toc.details.summary       `=>`
 s:defaults.highlight.enable          `=>`
@@ -831,6 +835,24 @@ Define the list style to use when generating a table of contents.
 The position at which to place the TOC, `0` is used for cursor line (default).
 If a number `> 0` is supplied, the TOC will be generated ABOVE that header.
 e.g. setting it to `1` will cause it to be the first heading of your document.
+
+==============================================================================
+`g:mkdx#settings.toc.update_on_write = 0`       *mkdx-setting-toc-update-on-write*
+
+This setting is disabled by default, set it to `1` to enable.
+Since this feature requires |autocmd|, your vim needs `has('autocmd')`
+for this to work.
+
+Using the |BufWritePre| |autocmd|, mkdx has the ability to update the table of
+contents automatically. The toc can be updated automatically when it is
+already present somewhere on the page (e.g. generated using <leader-i>).
+
+When the toc hasn't been generated and `g:mkdx#settings.toc.position > 0` then
+the toc will be generated at that position (as nth header in document).
+
+When `g:mkdx#settings.toc.position == 0` then the toc must first be generated
+at the desired position using <leader-i>. As soon as the toc is present it
+will be updated.
 
 ==============================================================================
 `g:mkdx#settings.toc.details.enable = 0`         *mkdx-setting-toc-details-enable*

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -7,7 +7,7 @@ let s:defaults          = {
       \ 'tokens':                  { 'enter': ['-', '*', '>'], 'bold': '**', 'italic': '*',
       \                              'list': '-', 'fence': '', 'header': '#', 'strike': '' },
       \ 'checkbox':                { 'toggles': [' ', '-', 'x'], 'update_tree': 2, 'initial_state': ' ' },
-      \ 'toc':                     { 'text': 'TOC', 'list_token': '-', 'position': 0,
+      \ 'toc':                     { 'text': 'TOC', 'list_token': '-', 'position': 0, 'update_on_write': 0,
       \                              'details': { 'enable': 0, 'summary': 'Click to expand {{toc.text}}' } },
       \ 'table':                   { 'divider': '|', 'header_divider': '-',
       \                              'align': { 'left': [], 'center': [], 'right': [],
@@ -94,6 +94,13 @@ endif
 if (g:mkdx#settings.fold.enable)
   setlocal foldmethod=expr
   setlocal foldexpr=mkdx#fold(v:lnum)
+endif
+
+if (has('autocmd'))
+  augroup MkdxAutocommands
+    au!
+    au BufWritePre *.md call mkdx#BeforeWrite()
+  augroup END
 endif
 
 if g:mkdx#settings.map.enable == 1

--- a/test/components/table-of-contents.vader
+++ b/test/components/table-of-contents.vader
@@ -1,5 +1,58 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Execute (Enable TOC save on write):
+  let g:mkdx#settings.toc.update_on_write = 1
+
+Given markdown (A file with headers and a table of contents):
+  # TOC
+
+  - [TOC](#toc)
+  - [Header 1](#header-1)
+  - [Header 2](#header-2)
+  - [Header 3](#header-3)
+      - [Subheader of 3](#subheader-of-3)
+      - [Subheader of 3](#subheader-of-3-1)
+  - [Header with link](#header-with-link)
+  - [Header with img](#header-with-img)
+
+  # Header 1
+  # Header 2
+  # Header 3
+  ## Subheader of 3
+  ## Subheader of 3
+  # Header [with link](https://google.com)
+  # Header ![with img](img.png)
+
+Do (execute before save hook):
+  Go# new header\<esc>:call mkdx#BeforeWrite()\<cr>\<esc>
+
+Expect markdown (A table of contents):
+  # TOC
+
+  - [TOC](#toc)
+  - [Header 1](#header-1)
+  - [Header 2](#header-2)
+  - [Header 3](#header-3)
+      - [Subheader of 3](#subheader-of-3)
+      - [Subheader of 3](#subheader-of-3-1)
+  - [Header with link](#header-with-link)
+  - [Header with img](#header-with-img)
+  - [new header](#new-header)
+
+  # Header 1
+  # Header 2
+  # Header 3
+  ## Subheader of 3
+  ## Subheader of 3
+  # Header [with link](https://google.com)
+  # Header ![with img](img.png)
+  # new header
+
+Execute (Disable TOC save on write):
+  let g:mkdx#settings.toc.update_on_write = 0
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Execute (Disable TOC in <details />):
   let g:mkdx#settings.toc.details.enable = 0
 
@@ -19,7 +72,7 @@ Given (A file with setex headers):
   # Header ![with img](img.png)
 
 Do (<leader>i):
-   i
+   i\<esc>
 
 Expect (A table of contents including the setex headers):
   # Table of Contents
@@ -56,7 +109,7 @@ Given (A file with headers):
   # Header ![with img](img.png)
 
 Do (<leader>i):
-   i
+   i\<esc>
 
 Expect (A table of contents):
   # Table of Contents
@@ -129,4 +182,4 @@ Expect (An updated table of contents):
 
 Execute (Reset settings):
   let g:mkdx#settings.toc.details.enable = 0
-  let g:mkdx#settings.toc.text = 'YOLO'
+  let g:mkdx#settings.toc.text = 'TOC'

--- a/test/setup.vader
+++ b/test/setup.vader
@@ -13,7 +13,7 @@ Execute (Setup):
         \ 'tokens':                  { 'enter': ['-', '*', '>'], 'bold': '**', 'italic': '*',
         \                              'list': '-', 'fence': '', 'header': '#', 'strike': '' },
         \ 'checkbox':                { 'toggles': [' ', '-', 'x'], 'update_tree': 2, 'initial_state': ' ' },
-        \ 'toc':                     { 'text': 'TOC', 'list_token': '-', 'position': 0,
+        \ 'toc':                     { 'text': 'TOC', 'list_token': '-', 'position': 0, 'update_on_write': 0,
         \                              'details': { 'enable': 0, 'summary': 'Click to expand {{toc.text}}' } },
         \ 'table':                   { 'divider': '|', 'header_divider': '-',
         \                              'align': { 'left': [], 'center': [], 'right': [],


### PR DESCRIPTION
This branch adds the ability to auto-update the TOC before the file is saved.
It is disabled by default and can be enabled by running `:let g:mkdx#settings.toc.update_on_write = 1`.

Behind the scenes, it uses the `BufWritePre` event in an `autocmd` so your vim needs `has('autocmd')` for this functionality to work.