### PR TITLE
Patch/fake toc caching

### DIFF
--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1485,10 +1485,13 @@ endfun
 
 fun! mkdx#BeforeWrite()
   if (g:mkdx#settings.toc.update_on_write != 0)
-    if (s:util.GetTOCPositionAndStyle()[0] > -1)
-      call mkdx#UpdateTOC()
-    elseif (g:mkdx#settings.toc.position > 0)
-      call mkdx#GenerateTOC()
+    if ((localtime() - get(s:util, '__before_write_time', 2)) >= 2)
+      let s:util.__before_write_time = localtime()
+      if (s:util.GetTOCPositionAndStyle()[0] > -1)
+        call mkdx#UpdateTOC()
+      elseif (g:mkdx#settings.toc.position > 0)
+        call mkdx#GenerateTOC()
+      endif
     endif
   end
 endfun

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -99,7 +99,7 @@ endif
 if (has('autocmd'))
   augroup MkdxAutocommands
     au!
-    au BufWritePre *.md call mkdx#BeforeWrite()
+    au BufWritePre *.md silent! call mkdx#BeforeWrite()
   augroup END
 endif
 


### PR DESCRIPTION
When saving in quick succession, it becomes quite slow to regenerate the TOC.
So every time the TOC is regenerated, a 2 second timeout is fired when saving.
If you saved within the last 2 seconds, no update will be executed.