### PR TITLE
Add modes to hasmapto calls

### DIFF
--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -194,13 +194,13 @@ fun! s:util.ToggleCompletions(old, new)
       setlocal completefunc=mkdx#Complete
       setlocal pumheight=15
       setlocal iskeyword+=\-
-      if (!hasmapto('<Plug>(mkdx-ctrl-n-compl)'))
+      if (!hasmapto('<Plug>(mkdx-ctrl-n-compl)', 'i'))
         imap <buffer><silent> <C-n> <Plug>(mkdx-ctrl-n-compl)
       endif
-      if (!hasmapto('<Plug>(mkdx-ctrl-p-compl)'))
+      if (!hasmapto('<Plug>(mkdx-ctrl-p-compl)', 'i'))
         imap <buffer><silent> <C-p> <Plug>(mkdx-ctrl-p-compl)
       endif
-      if (!hasmapto('<Plug>(mkdx-link-compl)'))
+      if (!hasmapto('<Plug>(mkdx-link-compl)', 'i'))
         imap <buffer><silent> # <Plug>(mkdx-link-compl)
       endif
     endif
@@ -216,15 +216,15 @@ fun! s:util.ToggleEnter(old, new)
     setlocal formatoptions-=r
     setlocal autoindent
 
-    if (!hasmapto('<Plug>(mkdx-enter)'))
+    if (!hasmapto('<Plug>(mkdx-enter)', 'i'))
       imap <buffer><silent> <Cr> <Plug>(mkdx-enter)
     endif
 
-    if (!hasmapto('<Plug>(mkdx-o)') && g:mkdx#settings.enter.o)
+    if (!hasmapto('<Plug>(mkdx-o)', 'n') && g:mkdx#settings.enter.o)
       nmap <buffer><silent> o <Plug>(mkdx-o)
     endif
 
-    if (!hasmapto('<Plug>(mkdx-shift-o)') && g:mkdx#settings.enter.shifto)
+    if (!hasmapto('<Plug>(mkdx-shift-o)', 'n') && g:mkdx#settings.enter.shifto)
       nmap <buffer><silent> O <Plug>(mkdx-shift-o)
     end
   endif

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -160,19 +160,19 @@ if g:mkdx#settings.map.enable == 1
     setlocal formatoptions-=r
     setlocal autoindent
 
-    if (!hasmapto('<Plug>(mkdx-shift-enter)') && g:mkdx#settings.enter.shift)
+    if (!hasmapto('<Plug>(mkdx-shift-enter)', 'i') && g:mkdx#settings.enter.shift)
       imap <buffer><silent> <S-CR> <Plug>(mkdx-shift-enter)
     endif
 
-    if (!hasmapto('<Plug>(mkdx-enter)'))
+    if (!hasmapto('<Plug>(mkdx-enter)', 'i'))
       imap <buffer><silent> <Cr> <Plug>(mkdx-enter)
     endif
 
-    if (!hasmapto('<Plug>(mkdx-o)') && g:mkdx#settings.enter.o)
+    if (!hasmapto('<Plug>(mkdx-o)', 'n') && g:mkdx#settings.enter.o)
       nmap <buffer><silent> o <Plug>(mkdx-o)
     endif
 
-    if (!hasmapto('<Plug>(mkdx-shift-o)') && g:mkdx#settings.enter.shifto)
+    if (!hasmapto('<Plug>(mkdx-shift-o)', 'n') && g:mkdx#settings.enter.shifto)
       nmap <buffer><silent> O <Plug>(mkdx-shift-o)
     end
   endif
@@ -180,7 +180,7 @@ if g:mkdx#settings.map.enable == 1
   for [label, prefix, mapmode, binding, plug, cmd] in s:bindings
     let mapping = (prefix ? g:mkdx#settings.map.prefix : '') . binding
 
-    if ((mapcheck(mapping, mapmode) == "") && !hasmapto(plug))
+    if ((mapcheck(mapping, mapmode) == "") && !hasmapto(plug, mapmode))
       if (!empty(cmd) && has('menu'))
         exe mapmode . 'noremenu <silent> <script> Plugin.mkdx.' . label . (mapmode == 'v' ? '\ (Visual)' : '') . '<tab>' . mapping . ' ' . cmd
       end


### PR DESCRIPTION
This is related to #62.

Removing `gv` from some visual mode plugs prevented them from being mapped after their normal mode counterparts were already mapped. The issue was the fact that `hasmapto` calls weren't supplied with the optional `mode` argument they take to check for plugs on a per-mode basis.
Instead, `hasmapto` simply checked wether a plug existed in any mode.