### PR TITLE
Resolves #62 - Change the way visual mode is restored after a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,15 +1265,15 @@ To prevent mapping of a key from happening, see: [unmapping functionality](#unma
 
 |description|modes|mapping|Execute|
 |----|----|-------|-------|
-|Prev checkbox state|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>-</kbd>|`<Plug>(mkdx-checkbox-prev)`|
-|Next checkbox state|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>=</kbd>|`<Plug>(mkdx-checkbox-next)`|
+|Prev checkbox state|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>-</kbd>|`<Plug>(mkdx-checkbox-prev-{n\|v})`|
+|Next checkbox state|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>=</kbd>|`<Plug>(mkdx-checkbox-next-{n\|v})`|
 |Promote header|normal|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>\[</kbd>|`<Plug>(mkdx-promote-header)`|
 |Demote header|normal|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>\]</kbd>|`<Plug>(mkdx-demote-header)`|
 |Toggle kbd shortcut|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>k</kbd>|`<Plug>(mkdx-toggle-to-kbd-{n\|v})`|
-|Toggle quote|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>'</kbd>|`<Plug>(mkdx-toggle-quote)`|
-|Toggle checkbox item|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>t</kbd>|`<Plug>(mkdx-toggle-checkbox)`|
-|Toggle checklist item|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>l</kbd><kbd>t</kbd>|`<Plug>(mkdx-toggle-checklist)`|
-|Toggle list item|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>l</kbd><kbd>l</kbd>|`<Plug>(mkdx-toggle-list)`|
+|Toggle quote|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>'</kbd>|`<Plug>(mkdx-toggle-quote-{n\|v})`|
+|Toggle checkbox item|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>t</kbd>|`<Plug>(mkdx-toggle-checkbox-{n\|v})`|
+|Toggle checklist item|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>l</kbd><kbd>t</kbd>|`<Plug>(mkdx-toggle-checklist-{n\|v})`|
+|Toggle list item|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>l</kbd><kbd>l</kbd>|`<Plug>(mkdx-toggle-list-{n\|v})`|
 |Wrap link|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>l</kbd><kbd>n</kbd>|`<Plug>(mkdx-wrap-link-{n\|v})`|
 |Italicize text|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>/</kbd>|`<Plug>(mkdx-mkdx-text-italic-{n\|v})`|
 |Bolden text|normal, visual|<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>b</kbd>|`<Plug>(mkdx-mkdx-text-bold-{n\|v}))`|
@@ -1352,10 +1352,10 @@ All of the functions of mkdx are mapped using `<Plug>` mappings.
 To disable a `<Plug>` mapping, first find it [here](#mappings) or at: `:h mkdx-plugs`.
 
 Say you want to disable the behaviour for toggling the next checkbox state.
-The corresponding `<Plug>` is called `<Plug>(mkdx-checkbox-next)`. To disable it, add the following to your _.vimrc_:
+The corresponding `<Plug>` is called `<Plug>(mkdx-checkbox-next-n)`. To disable it, add the following to your _.vimrc_:
 
 ```viml
-map <Plug> <Plug>(mkdx-checkbox-next)
+map <Plug> <Plug>(mkdx-checkbox-next-n)
 ```
 
 # Supported `grep` programs

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1233,6 +1233,12 @@ fun! mkdx#ToggleCheckboxState(...)
   silent! call repeat#set("\<Plug>(mkdx-checkbox-" . (reverse ? 'prev' : 'next') . ")")
 endfun
 
+fun! mkdx#MaybeRestoreVisual()
+  if (g:mkdx#settings.restore_visual)
+    normal! gv
+  endif
+endfun
+
 fun! mkdx#WrapText(...)
   let m = get(a:000, 0, 'n')
   let w = get(a:000, 1, '')
@@ -1282,23 +1288,23 @@ endfun
 
 fun! mkdx#ToggleList()
   call setline('.', s:util.ToggleLineType(getline('.'), 'list'))
-  silent! call repeat#set("\<Plug>(mkdx-toggle-list)")
+  silent! call repeat#set("\<Plug>(mkdx-toggle-list-n)")
 endfun
 
 fun! mkdx#ToggleChecklist()
   call setline('.', s:util.ToggleLineType(getline('.'), 'checklist'))
-  silent! call repeat#set("\<Plug>(mkdx-toggle-checklist)")
+  silent! call repeat#set("\<Plug>(mkdx-toggle-checklist-n)")
 endfun
 
 fun! mkdx#ToggleCheckboxTask()
   call setline('.', s:util.ToggleLineType(getline('.'), 'checkbox'))
-  silent! call repeat#set("\<Plug>(mkdx-toggle-checkbox)")
+  silent! call repeat#set("\<Plug>(mkdx-toggle-checkbox-n)")
 endfun
 
 fun! mkdx#ToggleQuote()
   let line = getline('.')
   if (!empty(line)) | call setline('.', s:util.transform(getline('.'), ['toggle-quote'])) | endif
-  silent! call repeat#set("\<Plug>(mkdx-toggle-quote)")
+  silent! call repeat#set("\<Plug>(mkdx-toggle-quote-n)")
 endfun
 
 fun! mkdx#ToggleHeader(...)

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -185,6 +185,9 @@ CONTENTS                                                         *mkdx-contents*
        Only valid
        Only list
 
+    Deprecated
+       V1.8.0
+
 ==============================================================================
 INTRODUCTION                                                 *mkdx-introduction*
 
@@ -2356,5 +2359,37 @@ option in this specific validation:
 
 The error will point out what valid options are in the context of the variable
 that you are trying to modify.
+
+==============================================================================
+DEPRECATED                                                     *mkdx-deprecated*
+
+The following section provides information about deprecated functionality,
+plugs, mappings etc...
+
+======
+V1.8.0
+
+Deprecated plugs:
+    - `mkdx-checkbox-next` replaced by:
+      - `mkdx-checkbox-next-n`
+      - `mkdx-checkbox-next-v`
+    - `mkdx-checkbox-prev` replaced by:
+      - `mkdx-checkbox-prev-n`
+      - `mkdx-checkbox-prev-v`
+    - `mkdx-toggle-quote` replaced by:
+      - `mkdx-toggle-quote-n`
+      - `mkdx-toggle-quote-v`
+    - `mkdx-toggle-checklist` replaced by:
+      - `mkdx-toggle-checklist-n`
+      - `mkdx-toggle-checklist-v`
+    - `mkdx-toggle-checkbox` replaced by:
+      - `mkdx-toggle-checkbox-n`
+      - `mkdx-toggle-checkbox-v`
+    - `mkdx-toggle-list` replaced by:
+      - `mkdx-toggle-list-n`
+      - `mkdx-toggle-list-v`
+
+While the old plugs will still work, they will no longer restore visual mode
+regardless of |mkdx-setting-restore-visual|.
 
 vim:tw=78:sw=4:ft=help:norl:

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -84,11 +84,12 @@ CONTENTS                                                         *mkdx-contents*
         <Plug>(mkdx-ctrl-n-compl)
         <Plug>(mkdx-ctrl-p-compl)
         <Plug>(mkdx-link-compl)
-        <Plug>(mkdx-checkbox-next)
-        <Plug>(mkdx-checkbox-prev)
+        <Plug>(mkdx-checkbox-next-n)
+        <Plug>(mkdx-checkbox-next-v)
+        <Plug>(mkdx-checkbox-prev-n)
+        <Plug>(mkdx-checkbox-prev-v)
         <Plug>(mkdx-promote-header)
         <Plug>(mkdx-demote-header)
-        <Plug>(mkdx-toggle-quote)
         <Plug>(mkdx-wrap-link-n)
         <Plug>(mkdx-wrap-link-v)
         <Plug>(mkdx-jump-to-header)
@@ -106,11 +107,16 @@ CONTENTS                                                         *mkdx-contents*
         <Plug>(mkdx-text-strike-v)
         <Plug>(mkdx-text-inline-code-n)
         <Plug>(mkdx-text-inline-code-v)
-        <Plug>(mkdx-toggle-checkbox)
-        <Plug>(mkdx-toggle-checklist)
-        <Plug>(mkdx-toggle-list)
+        <Plug>(mkdx-toggle-checkbox-n)
+        <Plug>(mkdx-toggle-checkbox-v)
+        <Plug>(mkdx-toggle-checklist-n)
+        <Plug>(mkdx-toggle-checklist-v)
+        <Plug>(mkdx-toggle-list-n)
+        <Plug>(mkdx-toggle-list-v)
         <Plug>(mkdx-toggle-to-kbd-n)
         <Plug>(mkdx-toggle-to-kbd-v)
+        <Plug>(mkdx-toggle-quote-n)
+        <Plug>(mkdx-toggle-quote-v)
         <Plug>(mkdx-o)
         <Plug>(mkdx-shift-o)
         <Plug>(mkdx-shift-enter)
@@ -287,11 +293,12 @@ for functions. Below is a list of all helptags:
     - |mkdx-plug-ctrl-n-compl|
     - |mkdx-plug-ctrl-p-compl|
     - |mkdx-plug-link-compl|
-    - |mkdx-plug-checkbox-next|
-    - |mkdx-plug-checkbox-prev|
+    - |mkdx-plug-checkbox-next-n|
+    - |mkdx-plug-checkbox-next-v|
+    - |mkdx-plug-checkbox-prev-n|
+    - |mkdx-plug-checkbox-prev-v|
     - |mkdx-plug-promote-header|
     - |mkdx-plug-demote-header|
-    - |mkdx-plug-toggle-quote|
     - |mkdx-plug-wrap-link-n|
     - |mkdx-plug-wrap-link-v|
     - |mkdx-plug-jump-to-header|
@@ -312,10 +319,15 @@ for functions. Below is a list of all helptags:
     - |mkdx-plug-wrap-text-in-backticks-n|
     - |mkdx-plug-wrap-text-in-backticks-v|
     - |mkdx-plug-toggle-checkbox|
+    - |mkdx-plug-toggle-checkbox-v|
     - |mkdx-plug-toggle-checklist|
+    - |mkdx-plug-toggle-checklist-v|
     - |mkdx-plug-toggle-list|
+    - |mkdx-plug-toggle-list-v|
     - |mkdx-plug-toggle-to-kbd-n|
     - |mkdx-plug-toggle-to-kbd-v|
+    - |mkdx-plug-toggle-quote|
+    - |mkdx-plug-toggle-quote-v|
     - |mkdx-plug-o|
     - |mkdx-plug-shift-o|
     - |mkdx-plug-enter|
@@ -1054,14 +1066,24 @@ using {repeat.vim} by Tim Pope (https://github.com/tpope/vim-repeat).
     `mkdx#CompleteLink()`
 
 ==============================================================================
-<Plug>(mkdx-checkbox-next)                             *mkdx-plug-checkbox-next*
+<Plug>(mkdx-checkbox-next-n)                         *mkdx-plug-checkbox-next-v*
 
     `:call mkdx#ToggleCheckboxState()<Cr>`
 
 ==============================================================================
-<Plug>(mkdx-checkbox-prev)                             *mkdx-plug-checkbox-prev*
+<Plug>(mkdx-checkbox-next-v)                         *mkdx-plug-checkbox-next-v*
+
+    `:call mkdx#ToggleCheckboxState()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>`
+
+==============================================================================
+<Plug>(mkdx-checkbox-prev-n)                         *mkdx-plug-checkbox-prev-n*
 
     `:call mkdx#ToggleCheckboxState(1)<Cr>`
+
+==============================================================================
+<Plug>(mkdx-checkbox-prev-v)                         *mkdx-plug-checkbox-prev-v*
+
+    `:call mkdx#ToggleCheckboxState(1)<Cr>:call mkdx#MaybeRestoreVisual()<Cr>`
 
 ==============================================================================
 <Plug>(mkdx-promote-header)                           *mkdx-plug-promote-header*
@@ -1074,9 +1096,14 @@ using {repeat.vim} by Tim Pope (https://github.com/tpope/vim-repeat).
     `:<C-U>call mkdx#ToggleHeader()<Cr>`
 
 ==============================================================================
-<Plug>(mkdx-toggle-quote)                               *mkdx-plug-toggle-quote*
+<Plug>(mkdx-toggle-quote-n)                           *mkdx-plug-toggle-quote-n*
 
     `:call mkdx#ToggleQuote()<Cr>`
+
+==============================================================================
+<Plug>(mkdx-toggle-quote-v)                           *mkdx-plug-toggle-quote-v*
+
+    `:call mkdx#ToggleQuote()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>`
 
 ==============================================================================
 <Plug>(mkdx-wrap-link-n)                                 *mkdx-plug-wrap-link-n*
@@ -1096,7 +1123,7 @@ using {repeat.vim} by Tim Pope (https://github.com/tpope/vim-repeat).
 ==============================================================================
 <Plug>(mkdx-tableize)                                       *mkdx-plug-tableize*
 
-    `:call mkdx#Tableize()<Cr>`
+    `:call mkdx#Tableize()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>`
 
 ==============================================================================
 <Plug>(mkdx-generate-toc)                               *mkdx-plug-generate-toc*
@@ -1173,18 +1200,34 @@ using {repeat.vim} by Tim Pope (https://github.com/tpope/vim-repeat).
     :<C-U>call mkdx#WrapText('v', '`', '`')<Cr>
 
 ==============================================================================
-<Plug>(mkdx-toggle-checkbox)                         *mkdx-plug-toggle-checkbox*
+<Plug>(mkdx-toggle-checkbox-n)                     *mkdx-plug-toggle-checkbox-n*
 
     `:call mkdx#ToggleCheckboxTask()<Cr>`
 
 ==============================================================================
-<Plug>(mkdx-toggle-checklist)                       *mkdx-plug-toggle-checklist*
+<Plug>(mkdx-toggle-checkbox-v)                     *mkdx-plug-toggle-checkbox-v*
+
+    `:call mkdx#ToggleCheckboxTask()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>`
+
+==============================================================================
+<Plug>(mkdx-toggle-checklist-n)                   *mkdx-plug-toggle-checklist-n*
 
     `:call mkdx#ToggleChecklist()<Cr>`
+
 ==============================================================================
-<Plug>(mkdx-toggle-list)                                 *mkdx-plug-toggle-list*
+<Plug>(mkdx-toggle-checklist-v)                   *mkdx-plug-toggle-checklist-v*
+
+    `:call mkdx#ToggleChecklist()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>`
+
+==============================================================================
+<Plug>(mkdx-toggle-list-n)                             *mkdx-plug-toggle-list-n*
 
     `:call mkdx#ToggleList()<Cr>`
+
+==============================================================================
+<Plug>(mkdx-toggle-list-v)                             *mkdx-plug-toggle-list-v*
+
+    `:call mkdx#ToggleList()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>`
 
 ==============================================================================
 <Plug>(mkdx-toggle-to-kbd-n)                         *mkdx-plug-toggle-to-kbd-n*
@@ -1251,12 +1294,12 @@ which it won't do anything anymore:
     `nmap <leader>= <Nop>`
     `vmap <leader>= <Nop>`
 
-Will disable |mkdx-plug-checkbox-next| in normal and visual mode.
+Will disable |mkdx-plug-checkbox-next-n| and |mkdx-plug-checkbox-next-v|.
 A better way in general, to prevent mkdx from setting an option is by
 remapping it's <Plug>, this will take care of both scenario's with one mapping
 and it is easier to understand "what" you unmapped, e.g:
 
-    `map <Plug> <Plug>(mkdx-checkbox-next)`
+    `map <Plug> <Plug>(mkdx-checkbox-next-n)`
 
 will result in the same as using regular `nmap` and `vmap`. For an overview of
 available <Plug> mappings that can be disabled, visit: |mkdx-plugs|.
@@ -1313,8 +1356,8 @@ When toggling an item which is nested in a list, the parent and child list
 items will be updated as well. Automatic updating of checkboxes
 can be disabled setting |mkdx-setting-checkbox-update-tree|.
 
-    `nmap <MAP_PREFIX>- <Plug>(mkdx-checkbox-next)`
-    `vmap <MAP_PREFIX>- <Plug>(mkdx-checkbox-next)`
+    `nmap <MAP_PREFIX>- <Plug>(mkdx-checkbox-next-n)`
+    `vmap <MAP_PREFIX>- <Plug>(mkdx-checkbox-next-v)`
 
 ==============================================================================
 Toggle checkbox backward                 *mkdx-mapping-toggle-checkbox-backward*
@@ -1329,8 +1372,8 @@ When toggling an item which is nested in a list, the parent and child list
 items will be updated as well. Automatic updating of checkboxes
 can be disabled setting |mkdx-setting-checkbox-update-tree|.
 
-    `nmap <MAP_PREFIX>= <Plug>(mkdx-checkbox-prev)`
-    `vmap <MAP_PREFIX>= <Plug>(mkdx-checkbox-prev)`
+    `nmap <MAP_PREFIX>= <Plug>(mkdx-checkbox-prev-n)`
+    `vmap <MAP_PREFIX>= <Plug>(mkdx-checkbox-prev-v)`
 
 ==============================================================================
 Wrap text in link                               *mkdx-mapping-wrap-text-in-link*
@@ -1415,8 +1458,8 @@ Toggles a markdown quote on the current line or on every nonblank line in a
 visual selection. This function restores visual selection if
 |mkdx-setting-restore-visual| is set.
 
-    `nmap <MAP_PREFIX>' <Plug>(mkdx-toggle-quote)`
-    `vmap <MAP_PREFIX>' <Plug>(mkdx-toggle-quote)`
+    `nmap <MAP_PREFIX>' <Plug>(mkdx-toggle-quote-n)`
+    `vmap <MAP_PREFIX>' <Plug>(mkdx-toggle-quote-v)`
 
 ==============================================================================
 List items                                             *mkdx-mapping-list-items*

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -46,18 +46,32 @@ if (!exists('g:mkdx#settings_initialized'))
   call mkdx#guard_settings()
 endif
 
+" backwards compat <= 1.8.0
 noremap         <silent> <Plug>(mkdx-checkbox-next)      :call      mkdx#ToggleCheckboxState()<Cr>
 noremap         <silent> <Plug>(mkdx-checkbox-prev)      :call      mkdx#ToggleCheckboxState(1)<Cr>
 noremap         <silent> <Plug>(mkdx-toggle-quote)       :call      mkdx#ToggleQuote()<Cr>
 noremap         <silent> <Plug>(mkdx-toggle-checkbox)    :call      mkdx#ToggleCheckboxTask()<Cr>
 noremap         <silent> <Plug>(mkdx-toggle-checklist)   :call      mkdx#ToggleChecklist()<Cr>
 noremap         <silent> <Plug>(mkdx-toggle-list)        :call      mkdx#ToggleList()<Cr>
+
+noremap         <silent> <Plug>(mkdx-checkbox-next-n)    :call      mkdx#ToggleCheckboxState()<Cr>
+noremap         <silent> <Plug>(mkdx-checkbox-prev-n)    :call      mkdx#ToggleCheckboxState(1)<Cr>
+noremap         <silent> <Plug>(mkdx-checkbox-next-v)    :call      mkdx#ToggleCheckboxState()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>
+noremap         <silent> <Plug>(mkdx-checkbox-prev-v)    :call      mkdx#ToggleCheckboxState(1)<Cr>:call mkdx#MaybeRestoreVisual()<Cr>
+noremap         <silent> <Plug>(mkdx-toggle-quote-n)     :call      mkdx#ToggleQuote()<Cr>
+noremap         <silent> <Plug>(mkdx-toggle-quote-v)     :call      mkdx#ToggleQuote()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>
+noremap         <silent> <Plug>(mkdx-toggle-checkbox-n)  :call      mkdx#ToggleCheckboxTask()<Cr>
+noremap         <silent> <Plug>(mkdx-toggle-checkbox-v)  :call      mkdx#ToggleCheckboxTask()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>
+noremap         <silent> <Plug>(mkdx-toggle-checklist-n) :call      mkdx#ToggleChecklist()<Cr>
+noremap         <silent> <Plug>(mkdx-toggle-checklist-v) :call      mkdx#ToggleChecklist()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>
+noremap         <silent> <Plug>(mkdx-toggle-list-n)      :call      mkdx#ToggleList()<Cr>
+noremap         <silent> <Plug>(mkdx-toggle-list-v)      :call      mkdx#ToggleList()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>
 noremap         <silent> <Plug>(mkdx-demote-header)      :<C-U>call mkdx#ToggleHeader()<Cr>
 noremap         <silent> <Plug>(mkdx-promote-header)     :<C-U>call mkdx#ToggleHeader(1)<Cr>
 noremap         <silent> <Plug>(mkdx-wrap-link-n)        :<C-U>call mkdx#WrapLink()<Cr>
 noremap         <silent> <Plug>(mkdx-wrap-link-v)        :call      mkdx#WrapLink('v')<Cr>
 noremap         <silent> <Plug>(mkdx-jump-to-header)     :call      mkdx#JumpToHeader()<Cr>
-noremap         <silent> <Plug>(mkdx-tableize)           :call      mkdx#Tableize()<Cr>
+noremap         <silent> <Plug>(mkdx-tableize)           :call      mkdx#Tableize()<Cr>:call mkdx#MaybeRestoreVisual()<Cr>
 noremap         <silent> <Plug>(mkdx-quickfix-links)     :call      mkdx#QuickfixDeadLinks()<Cr>
 noremap         <silent> <Plug>(mkdx-quickfix-toc)       :call      mkdx#QuickfixHeaders()<Cr>
 noremap         <silent> <Plug>(mkdx-generate-toc)       :call      mkdx#GenerateTOC()<Cr>
@@ -106,20 +120,20 @@ endif
 if g:mkdx#settings.map.enable == 1
   let s:gv       = g:mkdx#settings.restore_visual == 1 ? 'gv' : ''
   let s:bindings = [
-        \ ['Toggle\ checkbox\ backward',      1, 'n', '-',      '<Plug>(mkdx-checkbox-prev)',           ':call mkdx#ToggleCheckboxState(1)<cr>'],
-        \ ['Toggle\ checkbox\ forward',       1, 'n', '=',      '<Plug>(mkdx-checkbox-next)',           ':call mkdx#ToggleCheckboxState()<cr>'],
-        \ ['Toggle\ checkbox\ forward',       1, 'v', '-',      '<Plug>(mkdx-checkbox-prev)' . s:gv,    ':call mkdx#ToggleCheckboxState()<cr>' . s:gv],
-        \ ['Toggle\ checkbox\ backward',      1, 'v', '=',      '<Plug>(mkdx-checkbox-next)' . s:gv,    ':call mkdx#ToggleCheckboxState(1)<cr>' . s:gv],
+        \ ['Toggle\ checkbox\ backward',      1, 'n', '-',      '<Plug>(mkdx-checkbox-prev-n)',         ':call mkdx#ToggleCheckboxState(1)<cr>'],
+        \ ['Toggle\ checkbox\ forward',       1, 'n', '=',      '<Plug>(mkdx-checkbox-next-n)',         ':call mkdx#ToggleCheckboxState()<cr>'],
+        \ ['Toggle\ checkbox\ forward',       1, 'v', '-',      '<Plug>(mkdx-checkbox-prev-v)',         ':call mkdx#ToggleCheckboxState()<cr>:call mkdx#MaybeRestoreVisual()<cr>'],
+        \ ['Toggle\ checkbox\ backward',      1, 'v', '=',      '<Plug>(mkdx-checkbox-next-v)',         ':call mkdx#ToggleCheckboxState(1)<cr>:call mkdx#MaybeRestoreVisual()<cr>'],
         \ ['Promote\ header',                 1, 'n', '[',      '<Plug>(mkdx-promote-header)',          ':<C-U>call mkdx#ToggleHeader(1)<cr>'],
         \ ['Demote\ header',                  1, 'n', ']',      '<Plug>(mkdx-demote-header)',           ':<C-U>call mkdx#ToggleHeader()<cr>'],
-        \ ['Toggle\ quote',                   1, 'n', "'",      '<Plug>(mkdx-toggle-quote)',            ':call mkdx#ToggleQuote()<cr>'],
-        \ ['Toggle\ quote',                   1, 'v', "'",      '<Plug>(mkdx-toggle-quote)' . s:gv,     ':call mkdx#ToggleQuote()<cr>' . s:gv],
-        \ ['Toggle\ checkbox',                1, 'n', "t",      '<Plug>(mkdx-toggle-checkbox)',         ':call mkdx#ToggleCheckboxTask()<cr>'],
-        \ ['Toggle\ checkbox',                1, 'v', "t",      '<Plug>(mkdx-toggle-checkbox)' . s:gv,  ':call mkdx#ToggleCheckboxTask()<cr>' . s:gv],
-        \ ['Toggle\ checklist',               1, 'n', "lt",     '<Plug>(mkdx-toggle-checklist)',        ':call mkdx#ToggleChecklist()<cr>'],
-        \ ['Toggle\ checklist',               1, 'v', "lt",     '<Plug>(mkdx-toggle-checklist)' . s:gv, ':call mkdx#ToggleChecklist()<cr>' . s:gv],
-        \ ['Toggle\ list',                    1, 'n', "ll",     '<Plug>(mkdx-toggle-list)',             ':call mkdx#ToggleList()<cr>'],
-        \ ['Toggle\ list',                    1, 'v', "ll",     '<Plug>(mkdx-toggle-list)' . s:gv,      ':call mkdx#ToggleList()<cr>' . s:gv],
+        \ ['Toggle\ quote',                   1, 'n', "'",      '<Plug>(mkdx-toggle-quote-n)',          ':call mkdx#ToggleQuote()<cr>'],
+        \ ['Toggle\ quote',                   1, 'v', "'",      '<Plug>(mkdx-toggle-quote-v)',          ':call mkdx#ToggleQuote()<cr>:call mkdx#MaybeRestoreVisual()<cr>'],
+        \ ['Toggle\ checkbox',                1, 'n', "t",      '<Plug>(mkdx-toggle-checkbox-n)',       ':call mkdx#ToggleCheckboxTask()<cr>'],
+        \ ['Toggle\ checkbox',                1, 'v', "t",      '<Plug>(mkdx-toggle-checkbox-v)',       ':call mkdx#ToggleCheckboxTask()<cr>:call mkdx#MaybeRestoreVisual()<cr>'],
+        \ ['Toggle\ checklist',               1, 'n', "lt",     '<Plug>(mkdx-toggle-checklist-n)',      ':call mkdx#ToggleChecklist()<cr>'],
+        \ ['Toggle\ checklist',               1, 'v', "lt",     '<Plug>(mkdx-toggle-checklist-v)',      ':call mkdx#ToggleChecklist()<cr>:call mkdx#MaybeRestoreVisual()<cr>'],
+        \ ['Toggle\ list',                    1, 'n', "ll",     '<Plug>(mkdx-toggle-list-n)',           ':call mkdx#ToggleList()<cr>'],
+        \ ['Toggle\ list',                    1, 'v', "ll",     '<Plug>(mkdx-toggle-list-v)',           ':call mkdx#ToggleList()<cr>:call mkdx#MaybeRestoreVisual()<cr>'],
         \ ['Wrap\ link',                      1, 'n', 'ln',     '<Plug>(mkdx-wrap-link-n)',             ':<C-U>call mkdx#WrapLink()<cr>'],
         \ ['Wrap\ link',                      1, 'v', 'ln',     '<Plug>(mkdx-wrap-link-v)',             ':<C-U>call mkdx#WrapLink("v")<cr>'],
         \ ['Italic',                          1, 'n', '/',      '<Plug>(mkdx-text-italic-n)',           ':<C-U>call mkdx#WrapText("n", g:mkdx#settings.tokens.italic, g:mkdx#settings.tokens.italic, "mkdx-text-italic-n")<Cr>'],
@@ -130,7 +144,7 @@ if g:mkdx#settings.map.enable == 1
         \ ['Inline\ code',                    1, 'v', '`',      '<Plug>(mkdx-text-inline-code-v)',      ':<C-U>call mkdx#WrapText("v", "`", "`")<cr>'],
         \ ['Strike\ through',                 1, 'n', 's',      '<Plug>(mkdx-text-strike-n)',           ':<C-U>call mkdx#WrapText("n", "<strike>", "</strike>", "mkdx-text-strike-n")<cr>'],
         \ ['Strike\ through',                 1, 'v', 's',      '<Plug>(mkdx-text-strike-v)',           ':<C-U>call mkdx#WrapText("v", "<strike>", "</strike>")<cr>'],
-        \ ['Convert\ to\ table',              1, 'v', ',',      '<Plug>(mkdx-tableize)',                ':call mkdx#Tableize()<cr>'],
+        \ ['Convert\ to\ table',              1, 'v', ',',      '<Plug>(mkdx-tableize)',                ':call mkdx#Tableize()<cr>:call mkdx#MaybeRestoreVisual()<Cr>'],
         \ ['Generate\ /\ Update\ TOC',        1, 'n', 'i',      '<Plug>(mkdx-gen-or-upd-toc)',          ':call mkdx#GenerateOrUpdateTOC()<cr>'],
         \ ['Open\ TOC\ in\ quickfix',         1, 'n', 'I',      '<Plug>(mkdx-quickfix-toc)',            ':call mkdx#QuickfixHeaders()<cr>'],
         \ ['Open\ dead\ links\ in\ quickfix', 1, 'n', 'L',      '<Plug>(mkdx-quickfix-links)',          ':call mkdx#QuickfixDeadLinks()<cr>'],


### PR DESCRIPTION
This patch fixes #62. (And also mapping bug: #64)

Prior to this change, the setting `g:mkdx#settings.restore_visual` could not be changed at runtime, one had to restart Vim due to the way that visual mode was restored (applying `gv` after plug mapping).

To fix this extra `<Plug>` mappings were added and some existing ones were changed. Backwards compatibility is kept by keeping a copy of the original `<Plug>` mappings around, so they will still work if you created a custom mapping with them, just note that in visual mode, the selection will no longer be restored.

This is the list of plugs that are deprecated:
```viml
" backwards compat <= 1.8.0
noremap         <silent> <Plug>(mkdx-checkbox-next)      :call      mkdx#ToggleCheckboxState()<Cr>
noremap         <silent> <Plug>(mkdx-checkbox-prev)      :call      mkdx#ToggleCheckboxState(1)<Cr>
noremap         <silent> <Plug>(mkdx-toggle-quote)       :call      mkdx#ToggleQuote()<Cr>
noremap         <silent> <Plug>(mkdx-toggle-checkbox)    :call      mkdx#ToggleCheckboxTask()<Cr>
noremap         <silent> <Plug>(mkdx-toggle-checklist)   :call      mkdx#ToggleChecklist()<Cr>
noremap         <silent> <Plug>(mkdx-toggle-list)        :call      mkdx#ToggleList()<Cr>
```

And here a list of what replaced what:
- `<Plug>(mkdx-checkbox-next)` replaced by
    - `<Plug>(mkdx-checkbox-next-n)`
    - `<Plug>(mkdx-checkbox-next-v)`
- `<Plug>(mkdx-checkbox-prev)` replaced by
    - `<Plug>(mkdx-checkbox-prev-n)`
    - `<Plug>(mkdx-checkbox-prev-v)`
- `<Plug>(mkdx-toggle-quote)`  replaced by
    - `<Plug>(mkdx-toggle-quote-n)`
    - `<Plug>(mkdx-toggle-quote-v)`
- `<Plug>(mkdx-toggle-checkbox)` replaced by
    - `<Plug>(mkdx-toggle-checkbox-n)`
    - `<Plug>(mkdx-toggle-checkbox-v)`
- `<Plug>(mkdx-toggle-checklist)` replaced by
    - `<Plug>(mkdx-toggle-checklist-n)`
    - `<Plug>(mkdx-toggle-checklist-v)`
- `<Plug>(mkdx-toggle-list)` replaced by
    - `<Plug>(mkdx-toggle-list-n)`
    - `<Plug>(mkdx-toggle-list-v)`

All the docs have been updated to reflect the new `-{n|v}` style for these plugs.