### PR TITLE
delete generated table of contents into black hole register

### DIFF
--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1543,7 +1543,7 @@ fun! mkdx#UpdateTOC(...)
   let curpos                  = getpos('.')
   let [startc, endc, details] = s:util.GetTOCPositionAndStyle(opts)
 
-  silent! exe 'normal! :' . startc . ',' . endc . 'd'
+  silent! exe 'normal! :' . startc . ',' . endc . 'd _'
 
   let inslen = mkdx#GenerateTOC(1, details)
 


### PR DESCRIPTION
This patch fixes #68. Every time the old table of contents needs to be deleted, it will be deleted in the black hole register `"_`.