### PR TITLE
Handle double quotes inside table content

### DIFF
--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1401,7 +1401,7 @@ endfun
 fun! s:util.TableRowToList(line)
   return map(split(substitute(a:line, '^\s\+\|\s\+$', '', 'g'),
                  \ g:mkdx#settings.table.divider),
-           \ {idx, ln -> substitute(ln, '"', '\"', 'g')})
+           \ {idx, ln -> substitute(ln, '"', '\\"', 'g')})
 endfun
 
 fun! mkdx#OHandler()

--- a/test/components/tables.vader
+++ b/test/components/tables.vader
@@ -20,6 +20,26 @@ Expect (A markdown table):
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Given markdown (A markdown table containing double quoted content):
+  |       Name        | Age | Gender  |
+  |:-----------------:|:---:|:-------:|
+  |   Er'ic Cartman   | 10  | Unknown |
+  | "Kenny" McCormick | 10  |  Male   |
+  |    Stan Mar"sh    | 10  |  Male   |
+  |  K,le Brovlofski  | 10  |  Male   |
+
+Do (V5j<prefix>, (visually select the rows and convert)):
+  V5j ,
+
+Expect (Escaped CSV content):
+  "Name","Age","Gender"
+  "Er'ic Cartman","10","Unknown"
+  "\"Kenny\" McCormick","10","Male"
+  "Stan Mar\"sh","10","Male"
+  "K,le Brovlofski","10","Male"
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Given (Some rows of quoted CSV content):
   "Name","Age","Gender"
   "Er'ic Cartman","10","Unknown"


### PR DESCRIPTION
Double quotes did not get escaped with `\`. This created the potential for mkdx to spit out malformed CSV data when converting a markdown table back to CSV. This patch fixes #60 which implemented this functionality initially.