### PR TITLE
feat: add s:sw() function to support 'set shiftwidth=0'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1120,7 +1120,7 @@ let g:mkdx#settings = { 'enter': { 'shifto': 1 } }
 This setting defines behaviour to use when working with improperly indented
 markdown lists. At the moment it works for checklist items that do not have an
 `indent()` which is divisible by `shiftwidth`. In which case the indent will
-be rounded up to the next indent if it is greater than `&sw / 2` otherwise it
+be rounded up to the next indent if it is greater than `s:sw() / 2` otherwise it
 will be rounded down to the previous indent.
 
 ```viml

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -814,7 +814,7 @@ and place your cursor on it.
 This setting defines behaviour to use when working with improperly indented
 markdown files. At the moment it works for checklist items that do not have an
 |indent()| which is divisible by 'shiftwidth'. In which case the indent will
-be rounded up to the next indent if it is greater than `&sw / 2` otherwise it
+be rounded up to the next indent if it is greater than `s:sw() / 2` otherwise it
 will be rounded down to the previous indent.
 
 In the following example, the second item belongs under "hello" but the


### PR DESCRIPTION
The plugin uses `&sw` to set the indentation level this doesn't work for users that have `set shiftwidth=0` in their configuration files ( the setting is supposed to make it effectively the `tabstop` value.

The solution is extracted from `shiftwidth()` documentation:
```
if exists('*shiftwidth')
  func s:sw()
    return shiftwidth()
  endfunc
else
  func s:sw()
    return &sw
  endfunc
endif
```

Thanks to [Erasys GmbH](http://www.erasys.de/) for their support