### PR TITLE
Unicode characters in list items

### DIFF
--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1483,7 +1483,7 @@ fun! mkdx#EnterHandler()
   endif
 
   if (!empty(line) && g:mkdx#settings.enter.enable)
-    let len     = strlen(line)
+    let len     = strwidth(line)
     let at_end  = cnum > len
     let results = matchlist(line, sp_pat)
     let t       = get(results, 2, '')


### PR DESCRIPTION
Resolves #80 - Fixes an issue where unicode characters in a list item caused mkdx to not recognize them and fail to insert new list items.