### PR TITLE
Support wrapping with count (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,9 @@ Wrap the word under the cursor or a visual selection in an empty markdown link
 with <kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>l</kbd><kbd>n</kbd>. You'll end up in **insert** mode with your
 cursor between the parens, e.g. `(|)` where the pipe (`|`) character is the cursor.
 
+This mapping also takes a count, list as wrap mappings in the [bold / italic / inline-code / strikethrough](#wrap-as-bold--italic--inline-code--strikethrough).
+Doing this will wrap _count_ words within the body of the link.
+
 If what you're wrapping is an image (only works with visual selections at the moment), an image link will be created
 instead. To disable this behaviour, see: [`g:mkdx#settings.image_extension_pattern`](#gmkdxsettingsimage_extension_pattern).
 
@@ -521,7 +524,7 @@ Wrap the word (anywhere) under the cursor or a visual selection using the follow
 - <kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>s</kbd> => <strike>strikethrough</strike>
 
 As with all other mappings, all the *normal* mode mappings are repeatable.
-mkdx also supports supplying an optional `[count]` to these mappings, e.g.
+mkdx also supports supplying an optional _count_ to these mappings, e.g.
 
 Given text `Hello world` where the cursor can be anywhere inside the first word
 <kbd>2</kbd>+<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>b</kbd> will

--- a/README.md
+++ b/README.md
@@ -521,6 +521,11 @@ Wrap the word (anywhere) under the cursor or a visual selection using the follow
 - <kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>s</kbd> => <strike>strikethrough</strike>
 
 As with all other mappings, all the *normal* mode mappings are repeatable.
+mkdx also supports supplying an optional `[count]` to these mappings, e.g.
+
+Given text `Hello world` where the cursor can be anywhere inside the first word
+<kbd>2</kbd>+<kbd>[\<PREFIX\>](#gmkdxsettingsmapprefix)</kbd><kbd>b</kbd> will
+wrap both `Hello` and `world`: `**Hello world**`. This works for all the mappings above.
 
 ## Convert CSV to table (and back)
 

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -608,7 +608,7 @@ fun! s:util.WrapSelectionOrWord(...)
     let s_ch_w = (line[vcol - 2] == ' ' && line[vcol] == ' ')
     let mvcol  = vcol - 2
     let go_bk  = line[mvcol] == ' ' || mvcol < 0 ? '' : 'b'
-    let motion = s_ch_w ? 'l' : 'e'
+    let motion = s_ch_w ? 'l' : 'E'
     let cmd    = 'normal! ' . go_bk . '"z' . count . 'd' . motion
     exe cmd
     let zlen = strlen(@z)

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1331,7 +1331,7 @@ fun! mkdx#WrapStrike(...)
   let s = e ? g:mkdx#settings.tokens.strike : '<strike>'
   let z = e ? g:mkdx#settings.tokens.strike : '</strike>'
 
-  call s:util.WrapSelectionOrWord(m, s, z)
+  call s:util.WrapSelectionOrWord(m, s, z, get(v:, 'count1', 1))
 
   if (a != '')
     silent! call repeat#set("\<Plug>(" . a . ")")

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1348,7 +1348,7 @@ fun! mkdx#WrapLink(...) range
     call s:util.WrapSelectionOrWord(m, (img ? '!' : '') . '[', '](' . (img ? substitute(@z, '\n', '', 'g') : '') . ')')
     normal! f)
   else
-    call s:util.WrapSelectionOrWord(m, '[', ']()')
+    call s:util.WrapSelectionOrWord(m, '[', ']()', get(v:, 'count1', 1))
   end
 
   let @z = r

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -589,8 +589,10 @@ fun! s:util.WrapSelectionOrWord(...)
   let mode  = get(a:000, 0, 'n')
   let start = get(a:000, 1, '')
   let end   = get(a:000, 2, start)
+  let count = max([get(a:000, 3, 1), 1])
   let vcol  = virtcol('.')
-  let llen  = strlen(getline('.'))
+  let line  = getline('.')
+  let llen  = strlen(line)
   let _r    = @z
 
   if (mode != 'n')
@@ -603,9 +605,13 @@ fun! s:util.WrapSelectionOrWord(...)
     exe 'normal! i' . start
     call cursor(elnum, ecol)
   else
-    normal! "zdiw
+    let mvcol = vcol - 2
+    let go_bk = line[mvcol] == ' ' || mvcol < 0 ? '' : 'b'
+    let cmd = 'normal! ' . go_bk . '"z' . count . 'de'
+    exe cmd
+    let zlen = strlen(@z)
     let @z = start . @z . end
-    exe 'normal! "z' . ((vcol == llen) ? 'p' : 'P')
+    exe 'normal! "z' . ((vcol >= llen - zlen) ? 'p' : 'P')
   endif
 
   let zz = @z

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -605,9 +605,11 @@ fun! s:util.WrapSelectionOrWord(...)
     exe 'normal! i' . start
     call cursor(elnum, ecol)
   else
-    let mvcol = vcol - 2
-    let go_bk = line[mvcol] == ' ' || mvcol < 0 ? '' : 'b'
-    let cmd = 'normal! ' . go_bk . '"z' . count . 'de'
+    let s_ch_w = (line[vcol - 2] == ' ' && line[vcol] == ' ')
+    let mvcol  = vcol - 2
+    let go_bk  = line[mvcol] == ' ' || mvcol < 0 ? '' : 'b'
+    let motion = s_ch_w ? 'l' : 'e'
+    let cmd    = 'normal! ' . go_bk . '"z' . count . 'd' . motion
     exe cmd
     let zlen = strlen(@z)
     let @z = start . @z . end
@@ -1281,7 +1283,7 @@ fun! mkdx#WrapText(...)
   let x = get(a:000, 2, w)
   let a = get(a:000, 3, '')
 
-  call s:util.WrapSelectionOrWord(m, w, x)
+  call s:util.WrapSelectionOrWord(m, w, x, get(v:, 'count1', 1))
 
   if (a != '')
     silent! call repeat#set("\<Plug>(" . a . ")")
@@ -1766,7 +1768,6 @@ fun! mkdx#GenerateTOC(...)
 
     let prevlvl = lvl
   endfor
-
 
   if (do_details && (prevlvl - 1) > 0)
     let prevl = prevlvl - 1

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -1739,6 +1739,11 @@ In visual mode, it will wrap the entire visual selection in a link.
 
     Hello ` => ` [Hello]()
 
+This mapping may be prefixed with a [count] to mark [count] words starting
+at cursor position, moving to right, e.g. running `2<prefix>ln`:
+
+    Hello world `=>` [Hello world]()
+
 If a visual selection ends in an image extension (`.png` for example), an
 image link will be created instead.
 

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -1457,6 +1457,9 @@ Wrap the word under the cursor or a visual selection in bold. By default
     `nmap <MAP_PREFIX>b <Plug>(mkdx-text-bold-n)`
     `vmap <MAP_PREFIX>b <Plug>(mkdx-text-bold-v)`
 
+This mapping may be prefixed with a [count] to mark [count] words starting
+at cursor position, moving to right.
+
 ==============================================================================
 Wrap text in italic                           *mkdx-mapping-wrap-text-in-italic*
 
@@ -1467,6 +1470,9 @@ Wrap the word under the cursor or a visual selection in italic. By default
     `nmap <MAP_PREFIX>/ <Plug>(mkdx-text-italic-n)`
     `vmap <MAP_PREFIX>/ <Plug>(mkdx-text-italic-v)`
 
+This mapping may be prefixed with a [count] to mark [count] words starting
+at cursor position, moving to right.
+
 ==============================================================================
 Wrap text in strike-tag                   *mkdx-mapping-wrap-text-in-strike-tag*
 
@@ -1476,6 +1482,9 @@ tag.
     `nmap <MAP_PREFIX>s <Plug>(mkdx-text-strike-tag-n)`
     `vmap <MAP_PREFIX>s <Plug>(mkdx-text-strike-tag-v)`
 
+This mapping may be prefixed with a [count] to mark [count] words starting
+at cursor position, moving to right.
+
 ==============================================================================
 Wrap text in backticks                     *mkdx-mapping-wrap-text-in-backticks*
 
@@ -1484,6 +1493,9 @@ inline code block).
 
     nmap <MAP_PREFIX>` <Plug>(mkdx-text-italic-n)
     vmap <MAP_PREFIX>` <Plug>(mkdx-text-italic-v)
+
+This mapping may be prefixed with a [count] to mark [count] words starting
+at cursor position, moving to right.
 
 ==============================================================================
 Increment header level                     *mkdx-mapping-increment-header-level*

--- a/test/components/wrapping.vader
+++ b/test/components/wrapping.vader
@@ -40,6 +40,14 @@ Given (A line "Hello world"):
 
   hello
 
+Do (2<prefix>ln):
+  2 lnhttps://github.com/SidOfc/mkdx\<esc>
+
+Expect (Selection wrapped as link):
+  [Hello world](https://github.com/SidOfc/mkdx) hello world
+
+  hello
+
 Do (v2e<prefix>ln):
   v2e lnhttps://github.com/SidOfc/mkdx\<esc>
 
@@ -253,12 +261,18 @@ Do (<prefix>` (inline-code "Hello")):
 Expect (The word "Hello" to be inline-code):
   `Hello` world
 
+Do (Wrapping with count to wrap [count] words forward):
+  2 `
+
+Expect (The first two words to be wrapped):
+  `Hello world`
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Given (A paragraph of text):
-  Hello there
-  this is an awesome short
-  paragraph of text
+" Given (A paragraph of text):
+"   Hello there
+"   this is an awesome short
+"   paragraph of text
 
 " Do (Vj<prefix>`):
 "   Vj `
@@ -271,14 +285,6 @@ Given (A paragraph of text):
 "   this is an awesome short
 "   ```
 "   paragraph of text
-
-Do (Wrapping with count to wrap [count] words forward):
-  2 `
-
-Expect (The first two words to be wrapped):
-  `Hello there`
-  this is an awesome short
-  paragraph of text
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/components/wrapping.vader
+++ b/test/components/wrapping.vader
@@ -92,7 +92,7 @@ Given (A paragraph of text):
 Do (Vj<prefix>b):
   Vj b
 
-Expect (The word "Hello" to be a link):
+Expect (The word "Hello" to be bold):
   **Hello there
   this is an awesome short**
   paragraph of text
@@ -101,9 +101,18 @@ Expect (The word "Hello" to be a link):
 Do (wvj<prefix>b):
   wvj b
 
-Expect (The word "Hello" to be a link):
+Expect (The word "Hello" to be bold):
   Hello **there
   this is** an awesome short
+  paragraph of text
+  that I use to test links
+
+Do (Wrapping with count to wrap [count] words forward):
+  2 b
+
+Expect (The first two words to be wrapped):
+  **Hello there**
+  this is an awesome short
   paragraph of text
   that I use to test links
 
@@ -180,6 +189,12 @@ Do (<prefix>/ (italicize selection)):
 Expect (The selection to be italic):
   *Hello world*
 
+Do (Wrapping with count to wrap [count] words forward):
+  2 /
+
+Expect (The first two words to be wrapped):
+  *Hello world*
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Given (A line "Hello world"):
@@ -198,6 +213,12 @@ Do (<prefix>s (strike selection)):
   v2e s
 
 Expect (The selection to be strikethrough):
+  <strike>Hello world</strike>
+
+Do (Wrapping with count to wrap [count] words forward):
+  2 s
+
+Expect (The first two words to be wrapped):
   <strike>Hello world</strike>
 
 Given (A paragraph of text):
@@ -239,8 +260,8 @@ Given (A paragraph of text):
   this is an awesome short
   paragraph of text
 
-Do (Vj<prefix>`):
-  Vj `
+" Do (Vj<prefix>`):
+"   Vj `
 
 " FIXME mkdx#WrapCutTextInCodeBlock() might use a method which works with
 "       real buffers, but not the virtual "vader" buffers
@@ -250,6 +271,14 @@ Do (Vj<prefix>`):
 "   this is an awesome short
 "   ```
 "   paragraph of text
+
+Do (Wrapping with count to wrap [count] words forward):
+  2 `
+
+Expect (The first two words to be wrapped):
+  `Hello there`
+  this is an awesome short
+  paragraph of text
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/test/components/wrapping.vader
+++ b/test/components/wrapping.vader
@@ -126,6 +126,17 @@ Expect (The first two words to be wrapped):
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Given (Text with a WORD):
+  Hello-world
+
+Do (<prefix>b):
+   b
+
+Expect (the WORD to be wrapped):
+  **Hello-world**
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Given (A paragraph of text):
   Hello there
   this is an awesome short


### PR DESCRIPTION
This PR adds functionality and changes some default behavior based on feature request #103.

- Instead of wrapping `word`, it will now wrap `WORD` instead (changed default behavior)
- It allows users to prefix the following mappings with a `[COUNT]`:
    - Wrapping bold
    - Wrapping italic
    - Wrapping strikethrough
    - Wrapping inline code
    - Wrapping links

Also added tests to verify the behavior works as intended.

Additionally, some bugs were fixed which now allow mkdx to handle wrapping single-character "words" a bit better, and wrapping last-word-in-line is also less buggy now.