### PR TITLE
#100 enhance gf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1448,6 +1448,7 @@ To prevent mapping of a key from happening, see: [unmapping functionality](#unma
 |<kbd>ctrl</kbd>+<kbd>n</kbd> handler|insert|<kbd>ctrl</kbd>+<kbd>n</kbd>|`<Plug>(mkdx-ctrl-n-compl)`|
 |<kbd>ctrl</kbd>+<kbd>p</kbd> handler|insert|<kbd>ctrl</kbd>+<kbd>p</kbd>|`<Plug>(mkdx-ctrl-p-compl)`|
 |<kbd>#</kbd> handler|insert|<kbd>#</kbd>|`<Plug>(mkdx-link-compl)`|
+|Jump to file / URL|normal|<kbd>g</kbd><kbd>f</kbd>|`<Plug>(mkdx-gf)`|
 
 ## Remapping functionality
 

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -621,6 +621,13 @@ fun! s:util.isAlreadyWrapped(id)
   return !empty(found_match)
 endfun
 
+fun! mkdx#gf()
+  if s:util.isAlreadyWrapped('mkdx-text-link-n')
+  else
+    normal! gf
+  endif
+endfun
+
 fun! s:util.hlBounds(type)
   let group = get(s:wrap_hl_map, a:type, s:util.hlAtCursor())
   let slnum = line('.')

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -127,6 +127,7 @@ CONTENTS                                                         *mkdx-contents*
         <Plug>(mkdx-insert-kbd)
         <Plug>(mkdx-fence-tilde)
         <Plug>(mkdx-fence-backtick)
+        <Plug>(mkdx-gf)
 
     Mappings
         Insert link completion
@@ -152,6 +153,7 @@ CONTENTS                                                         *mkdx-contents*
         Toggle checklist
         Toggle list
         Toggle kbd shortcut
+        Jump to file or url
 
     Functions
         mkdx#ToggleCheckboxState()
@@ -181,6 +183,7 @@ CONTENTS                                                         *mkdx-contents*
         mkdx#fold()
         mkdx#WrapText()
         mkdx#WrapStrike()
+        mkdx#gf()
 
     Errors
        Type
@@ -343,6 +346,7 @@ for functions. Below is a list of all helptags:
     - |mkdx-plug-insert-kbd|
     - |mkdx-plug-fence-tilde|
     - |mkdx-plug-fence-backtick|
+    - |mkdx-plug-gf|
 
 - |mkdx-mappings|
     - |mkdx-mapping-insert-link-completion|
@@ -368,6 +372,7 @@ for functions. Below is a list of all helptags:
     - |mkdx-mapping-toggle-checklist|
     - |mkdx-mapping-toggle-list|
     - |mkdx-mapping-toggle-kbd-shortcut|
+    - |mkdx-mapping-jump-to-file-or-url|
 
 - |mkdx-functions|
     - |mkdx-function-toggle-checkbox|
@@ -396,6 +401,7 @@ for functions. Below is a list of all helptags:
     - |mkdx-function-insert-ctrl-p-handler|
     - |mkdx-function-complete-link|
     - |mkdx-function-fold|
+    - |mkdx-function-gf|
 
 - |mkdx-errors|
     - |mkdx-error-type|
@@ -1335,6 +1341,11 @@ using {repeat.vim} by Tim Pope (https://github.com/tpope/vim-repeat).
     `<C-R>=mkdx#InsertFencedCodeBlock('```')<Cr>kA`
 
 ==============================================================================
+<Plug>(mkdx-gf)                                                   *mkdx-plug-gf*
+
+    `:<C-U>call mkdx#gf()<Cr>`
+
+==============================================================================
 MAPPINGS                                                         *mkdx-mappings*
 
 These are the default mappings set by this plugin. Both
@@ -1665,6 +1676,17 @@ In normal mode, it will attempt to convert the current |WORD| to an expanded
 kbd expression. In visual mode, the current visual selection will be expanded.
 
 Examples can be found at |mkdx-function-toggle-to-kbd|
+
+==============================================================================
+Jump to file or url                           *mkdx-mapping-jump-to-file-or-url*
+                                                                            gf
+
+This mapping works like regular |gf| unless the cursor is positioned on a
+markdown link. When on a link, mkdx will open the file or url inbetween the
+parentheses. The cursor can be anywhere on the link and this will work.
+
+When the link is not a file, but a URL, mkdx will use an `open` shell command.
+If `open` is not available, it will silently fail.
 
 ==============================================================================
 FUNCTIONS                                                       *mkdx-functions*
@@ -2357,6 +2379,16 @@ See |mkdx-setting-tokens-stike| for more details. Both arguments are passed to
 `mkdx#WrapText`. When {mode} is omitted it defaults to 'n' and the current
 word under the cursor will be wrapped. When {plug} is omitted, it defaults to
 an empty string.
+
+==============================================================================
+mkdx#gf()                                                     *mkdx-function-gf*
+
+This function is used when positioned within markdown links, it provides
+functionality required for |mkdx-mapping-jump-to-file-or-url| (<gf>).
+
+When on a markdown link, will open the location, if it is a file, regular |gf|
+is used to open the file, when it is a URL (anything starting with `http`)
+it will use `open` to open the URL, fails silently otherwise.
 
 ==============================================================================
 |ERRORS|                                                             *mkdx-errors*

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -99,6 +99,8 @@ inoremap        <silent> <Plug>(mkdx-ctrl-n-compl)       <C-R>=mkdx#InsertCtrlNH
 inoremap        <silent> <Plug>(mkdx-ctrl-p-compl)       <C-R>=mkdx#InsertCtrlPHandler()<Cr>
 inoremap <expr> <silent> <Plug>(mkdx-link-compl)         mkdx#CompleteLink()
 
+nnoremap gf :<C-U>call mkdx#gf()<Cr>
+
 if (g:mkdx#settings.links.fragment.complete)
   setlocal completefunc=mkdx#Complete
   setlocal pumheight=15

--- a/ftplugin/markdown/mkdx.vim
+++ b/ftplugin/markdown/mkdx.vim
@@ -90,6 +90,7 @@ noremap         <silent> <Plug>(mkdx-toggle-to-kbd-n)    :call      mkdx#ToggleT
 noremap         <silent> <Plug>(mkdx-toggle-to-kbd-v)    :<C-U>call mkdx#ToggleToKbd('v')<Cr>
 noremap         <silent> <Plug>(mkdx-shift-o)            :<C-U>call mkdx#ShiftOHandler()<Cr>
 noremap         <silent> <Plug>(mkdx-o)                  :<C-U>call mkdx#OHandler()<Cr>
+noremap         <silent> <Plug>(mkdx-gf)                 :<C-U>call mkdx#gf()<Cr>
 inoremap        <silent> <Plug>(mkdx-enter)              <C-R>=mkdx#EnterHandler()<Cr>:setlocal autoindent<Cr>
 inoremap        <silent> <Plug>(mkdx-shift-enter)        <C-R>=mkdx#ShiftEnterHandler()<Cr>
 inoremap        <silent> <Plug>(mkdx-insert-kbd)         <kbd></kbd>F<
@@ -98,8 +99,6 @@ inoremap        <silent> <Plug>(mkdx-fence-backtick)     <C-R>=mkdx#InsertFenced
 inoremap        <silent> <Plug>(mkdx-ctrl-n-compl)       <C-R>=mkdx#InsertCtrlNHandler()<Cr>
 inoremap        <silent> <Plug>(mkdx-ctrl-p-compl)       <C-R>=mkdx#InsertCtrlPHandler()<Cr>
 inoremap <expr> <silent> <Plug>(mkdx-link-compl)         mkdx#CompleteLink()
-
-nnoremap gf :<C-U>call mkdx#gf()<Cr>
 
 if (g:mkdx#settings.links.fragment.complete)
   setlocal completefunc=mkdx#Complete
@@ -160,7 +159,8 @@ if g:mkdx#settings.map.enable == 1
         \ ['Toggle\ to\ kbd\ tag',            1, 'v', 'k',      '<Plug>(mkdx-toggle-to-kbd-v)',         ':call mkdx#ToggleToKbd("v")<cr>'],
         \ ['Insert\ kbd\ tag',                0, 'i', '<<tab>', '<Plug>(mkdx-insert-kbd)',              '<kbd></kbd>2hcit'],
         \ ['Backtick\ fenced\ code\ block',   0, 'i', '```',    '<Plug>(mkdx-fence-backtick)',          '<C-R>=mkdx#FencedCodeBlock("`")<Cr>kA'],
-        \ ['tilde\ fenced\ code\ block',      0, 'i', '~~~',    '<Plug>(mkdx-fence-tilde)',             '<C-R>=mkdx#FencedCodeBlock("~")<Cr>kA']
+        \ ['tilde\ fenced\ code\ block',      0, 'i', '~~~',    '<Plug>(mkdx-fence-tilde)',             '<C-R>=mkdx#FencedCodeBlock("~")<Cr>kA'],
+        \ ['Jump to file / open URL',         0, 'n', 'gf',     '<Plug>(mkdx-gf)',                      ':<C-U>call mkdx#gf()<Cr>']
         \ ]
 
   if (g:mkdx#settings.links.fragment.complete)


### PR DESCRIPTION
This PR enhances gf to work from anywhere inside a markdown link.
In addition to that, it will open URL's as well using an available `open` shell command, if `open` is not available it will fail silently.

At first I figured it may be a bad idea to overwrite native `gf` but by checking if we are inside a markdown link and only then enhancing it, I don't think this is needed.

Note: on neovim, this seems to open URLs (on firefox atleast) in a new browser window rather than opening in the same window, regular vim handles this in a more desired way.