### PR TITLE
Conceal link URLs when &conceallevel is set (#108)

### DIFF
--- a/after/syntax/markdown/mkdx.vim
+++ b/after/syntax/markdown/mkdx.vim
@@ -24,6 +24,7 @@ syn match   mkdxLink '\(https\?:\)\?\/\/[^ ]\{-}\(\.\w\+\)\+'
 syn match   mkdxKbdText '\%(kbd>\)\@<=[^ >]\+\%(<\/\?kbd\)\@='
 syn match   mkdxKbdOpening '<kbd>'
 syn match   mkdxKbdEnding '<\/kbd>'
+syn region  markdownLink matchgroup=markdownLinkDelimiter start="(" end=")" keepend contained conceal contains=markdownUrl
 
 " CriticMarkup
 " reference: http://criticmarkup.com


### PR DESCRIPTION
This hides the URL part of markdown links including the parentheses. It will not however, hide the square brackets around links, this requires more research into how vim-pandoc-syntax actually applies highlighting (installing the plugin, using it to see if it is simple or rather complex).