### PR TITLE
Fix unknown escape character in alacritty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1130,8 +1130,8 @@ This can usually be fixed by setting them manually for your emulator, included f
 >
 > **[Alacritty](https://github.com/jwilm/alacritty)**, under `key_bindings`, add following to your `~/.config/alacritty/alacritty.yml`:
 >
->     - { key: Return,   mods: Shift,   chars: "\x1b\[13;2u" }
->     - { key: Return,   mods: Control, chars: "\x1b\[13;5u" }
+>     - { key: Return,   mods: Shift,   chars: "\x1b[13;2u" }
+>     - { key: Return,   mods: Control, chars: "\x1b[13;5u" }
 
 ```viml
 " :h mkdx-setting-enter-shift


### PR DESCRIPTION
When copy pasting the config for alacritty, I was getting an error:
Problem with config: while parsing a quoted scalar, found unknown escape character at line 85 column 44

Saw this on SO: https://stackoverflow.com/a/42461580/3788603

And it doesn't include the extra `\` character.