### PR TITLE
Add setting to configure increment on numbered list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1192,6 +1192,15 @@ This setting is [auto updated](#gmkdxsettingsauto_updateenable) when available.
 let g:mkdx#settings = { 'enter': { 'enable': 1 } }
 ```
 
+## `g:mkdx#settings.enter.increment`
+
+This setting defines increment done for each new item in numbered list, Default value is `1` setting `0` will keep current index on new item.
+
+```viml
+" :h mkdx-setting-enter-increment
+let g:mkdx#settings = { 'enter': { 'increment': 0 } }
+```
+
 ## `g:mkdx#settings.enter.shift`
 
 When enabled, pressing <kbd>shift</kbd>+<kbd>enter</kbd> will indent the next line upto the level of the text on the current line.

--- a/autoload/mkdx.vim
+++ b/autoload/mkdx.vim
@@ -1030,7 +1030,7 @@ fun! s:util.NextListNumber(current, depth, ...)
   let curr  = substitute(a:current, '^ \+\| \+$', '', 'g')
   let parts = split(curr, '\.')
   let incr  = get(a:000, 0, 0)
-  let incr  = incr < 0 ? incr : 1
+  let incr  = incr < 0 ? incr : g:mkdx#settings.enter.increment
 
   if (len(parts) > a:depth) | let parts[a:depth] = str2nr(parts[a:depth]) + incr | endif
   return join(parts, '.') . ((match(curr, '\.$') > -1) ? '.' : '')

--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -691,6 +691,14 @@ When enabled, pressing <Tab> and <S-Tab> will indent / unindent lines and
 additionally renumber numbered list items.
 
 ==============================================================================
+`g:mkdx#settings.enter.increment = 1`               *mkdx-setting-enter-increment*
+
+This setting defines increment done for each new item in numbered list,
+Default value is `1` setting `0` will keep current index on new item.
+
+    `let g:mkdx#settings = { 'enter': { 'increment': 0 } }`
+
+==============================================================================
 `g:mkdx#settings.enter.shift = 0`                       *mkdx-setting-enter-shift*
 
 Disabled by default, set to `1` to enable.

--- a/plugin/mkdx.vim
+++ b/plugin/mkdx.vim
@@ -2,7 +2,7 @@ let s:defaults = {
       \ 'image_extension_pattern': 'a\?png\|jpe\?g\|gif',
       \ 'restore_visual':          1,
       \ 'gf_on_steroids':          0,
-      \ 'enter':                   { 'enable': 1, 'shift': 0, 'malformed': 1, 'o': 1, 'shifto': 1 },
+      \ 'enter':                   { 'enable': 1, 'shift': 0, 'malformed': 1, 'o': 1, 'shifto': 1, 'increment': 1 },
       \ 'tab':                     { 'enable': 1 },
       \ 'map':                     { 'prefix': '<leader>', 'enable': 1 },
       \ 'tokens':                  { 'enter': ['-', '*', '>'], 'bold': '**', 'italic': '*',


### PR DESCRIPTION
`g:mkdx#settings.enter.increment` allows to configure how new item index
is increment or decremented in case reorder/ delete

This is useful if you don't want to explicitly number items