### PR TITLE
Add instruction for installing via packer.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ cd ~/.vim/bundle
 git clone https://github.com/SidOfc/mkdx
 ```
 
+[packer.nvim](https://github.com/wbthomason/packer.nvim)
+```sh
+use 'SidOfc/mkdx'
+```
+
 Pack (Vim's native plugin system).
 
 **vim:**


### PR DESCRIPTION
Adds a paragraph explaining how to install the plugin using packer.nvim.

Tested on 
- macOS Big Sur 11.6.1
- neovim v0.5.1