### PR TITLE
Fix helptags

### DIFF
--- a/doc/mkdx.txt
+++ b/doc/mkdx.txt
@@ -536,7 +536,7 @@ Configure the `pumheight` used in markdown files.
 Set to `0` to prevent `pumheight` from being modified.
 
 ==============================================================================
-`g:mkdx#settings.links.fragment`           *mkdx-setting-links-fragment-pumheight*
+`g:mkdx#settings.links.fragment`           *mkdx-setting-links-fragment-completeopt*
   `.completeopt = 'noinsert,menuone'`
 
 Configure the `completeopt` used for fragment completion.


### PR DESCRIPTION
`helptags` generation is failing with error
```log
E154: Duplicate tag "mkdx-setting-links-fragment-pumheight" in file ~/.vim/bundle/mkdx/doc/mkdx.txt
```
This PR fixes that